### PR TITLE
Prefer Psych as the YAML engine on 1.9.2

### DIFF
--- a/lib/rake/baseextensiontask.rb
+++ b/lib/rake/baseextensiontask.rb
@@ -4,6 +4,12 @@ require 'rake'
 require 'rake/clean'
 require 'rake/tasklib'
 require 'rbconfig'
+
+begin
+  require 'psych'
+rescue LoadError
+end
+
 require 'yaml'
 require 'pathname'
 

--- a/tasks/bin/cross-ruby.rake
+++ b/tasks/bin/cross-ruby.rake
@@ -19,6 +19,12 @@
 
 require 'rake'
 require 'rake/clean'
+
+begin
+  require 'psych'
+rescue LoadError
+end
+
 require 'yaml'
 
 # load compiler helpers


### PR DESCRIPTION
Rubygems defaults to psych as the YAML parser, rake-compiler should too.
