### PR TITLE
Do not explicitly depend on rake

### DIFF
--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -14,9 +14,6 @@ GEM_SPEC = Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.8.6"
   s.required_rubygems_version = ">= 1.3.5"
 
-  # dependencies
-  s.add_dependency  'rake'
-
   # development dependencies
   s.add_development_dependency 'rspec', '~> 2.6.0'
   s.add_development_dependency 'cucumber', '~> 0.10.6'


### PR DESCRIPTION
In some cases, being forced to install rake from rubygems can be bad, like if you are using a customized rake.

Are there people who are running 1.8.6 or newer that do not have rake installed with their distro of ruby?
