### PR TITLE
Emit JRuby cross-compile warning only when actually doing the cross-compilation

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -38,10 +38,6 @@ module Rake
 
     def binary(platform = nil)
       if platform == "java"
-	warn_once <<-EOF
-Compiling a native C extension on JRuby. This is discouraged and a 
-Java extension should be preferred.
-        EOF
         "#{name}.#{RbConfig::MAKEFILE_CONFIG['DLEXT']}"
       else
         super
@@ -106,6 +102,12 @@ Rerun `rake` under MRI Ruby 1.8.x/1.9.x to cross/native compile.
       # binary in temporary folder depends on makefile and source files
       # tmp/extension_name/extension_name.{so,bundle}
       file "#{tmp_path}/#{binary(platf)}" => ["#{tmp_path}/Makefile"] + source_files do
+        jruby_compile_msg = <<-EOF
+Compiling a native C extension on JRuby. This is discouraged and a 
+Java extension should be preferred.
+        EOF
+        warn_once(jruby_compile_msg) if defined?(JRUBY_VERSION)
+
         chdir tmp_path do
           sh make
         end

--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -67,15 +67,6 @@ module Rake
         install "#{tmp_path}/#{binary(platf)}", "#{lib_path}/#{binary(platf)}"
       end
 
-      not_jruby_compile_msg = <<-EOF
-WARNING: You're cross-compiling a binary extension for JRuby, but are using
-another interpreter. If your Java classpath or extension dir settings are not
-correctly detected, then either check the appropriate environment variables or
-execute the Rake compilation task using the JRuby interpreter.
-(e.g. `jruby -S rake compile:java`)
-      EOF
-      warn_once(not_jruby_compile_msg) unless defined?(JRUBY_VERSION)
-
       file "#{tmp_path}/#{binary(platf)}" => "#{tmp_path}/.build" do
 
         class_files = FileList["#{tmp_path}/**/*.class"].
@@ -92,6 +83,15 @@ execute the Rake compilation task using the JRuby interpreter.
       end
 
       file "#{tmp_path}/.build" => [tmp_path] + source_files do
+        not_jruby_compile_msg = <<-EOF
+WARNING: You're cross-compiling a binary extension for JRuby, but are using
+another interpreter. If your Java classpath or extension dir settings are not
+correctly detected, then either check the appropriate environment variables or
+execute the Rake compilation task using the JRuby interpreter.
+(e.g. `jruby -S rake compile:java`)
+        EOF
+        warn_once(not_jruby_compile_msg) unless defined?(JRUBY_VERSION)
+
         classpath_arg = java_classpath_arg(@classpath)
         debug_arg     = @debug ? '-g' : ''
 


### PR DESCRIPTION
Previously it was emitted when running any rake task or even just `rake -T`.
