### PR TITLE
Pass extra Rake cmd line args to extconf.rb

### DIFF
--- a/lib/rake/baseextensiontask.rb
+++ b/lib/rake/baseextensiontask.rb
@@ -24,6 +24,7 @@ module Rake
     attr_accessor :platform
     attr_accessor :config_options
     attr_accessor :source_pattern
+    attr_accessor :extra_options
 
     def platform
       @platform ||= RUBY_PLATFORM
@@ -42,6 +43,7 @@ module Rake
       @ext_dir = "ext/#{@name}"
       @lib_dir = 'lib'
       @config_options = []
+      @extra_options = ARGV.select { |i| i =~ /\A--?/ }
     end
 
     def define

--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -140,10 +140,14 @@ Rerun `rake` under MRI Ruby 1.8.x/1.9.x to cross/native compile.
         # add options to command
         cmd.push(*options)
 
+        # add any extra command line options
+        unless extra_options.empty?
+          cmd.push('--', *extra_options)
+        end
+
         chdir tmp_path do
           # FIXME: Rake is broken for multiple arguments system() calls.
           # Add current directory to the search path of Ruby
-          # Also, include additional parameters supplied.
           sh cmd.join(' ')
         end
       end


### PR DESCRIPTION
Tested on Win7 32bit in psych repo using `rake compile -- --with-libyaml-dir=c:/devlibs/libyaml`
