### PR TITLE
Detect 32bit mingw-gcc executable for cross compile

### DIFF
--- a/lib/rake/extensioncompiler.rb
+++ b/lib/rake/extensioncompiler.rb
@@ -39,7 +39,7 @@ module Rake
       paths = ENV['PATH'].split(File::PATH_SEPARATOR)
 
       # the pattern to look into (captures *nix and windows executables)
-      pattern = "*mingw*gcc{,.*}"
+      pattern = "i?86*mingw*gcc{,.*}"
 
       @mingw_gcc_executable = paths.find do |path|
         # cleanup paths before globbing


### PR DESCRIPTION
Hi Luis,

the newer mingw versions on Ubuntu always install 32- and 64-bit environments together. With the current mingw-gcc detection, it happens, that the 64bit version is used, wrongly.

I tried some versions of mingw with the following result:

<table>
    <tr><th>version</th><th>32bit</th><th>64bit</th></tr>
    <tr><td>gcc 4.2.1 (debian)</td><td>i586-mingw32msvc-gcc</td><td>-</td></tr>
    <tr><td>gcc 4.4.4 (debian)</td><td>i586-mingw32msvc-gcc</td><td>amd64-mingw32msvc-gcc</td></tr>
    <tr><td>gcc 4.6.1 (debian)</td><td>i686-w64-mingw32-gcc</td><td>x86_64-w64-mingw32-gcc</td></tr>
    <tr><td>gcc 4.2.1 (macport)</td><td>i386-mingw32-gcc</td><td>-</td></tr>
</table>


To only choose the 32bit version, I would propose the i*86-pattern as in the attached commit.
