### PR TITLE
Remove the caching of source_files

### DIFF
--- a/lib/rake/baseextensiontask.rb
+++ b/lib/rake/baseextensiontask.rb
@@ -73,7 +73,7 @@ module Rake
     end
 
     def source_files
-      @source_files ||= FileList["#{@ext_dir}/#{@source_pattern}"]
+      FileList["#{@ext_dir}/#{@source_pattern}"]
     end
 
     def warn_once(message)


### PR DESCRIPTION
This allows me to run a task which generates java source files, prior to having rake-compiler compile them.

This is especially useful when you need to generate Thrift java sources or, should your life be one of pain and misery, wsimport (WSDL SOAP to java).
