### PR TITLE
Qualify mingw32-gcc as a valid MinGW compiler

### DIFF
--- a/lib/rake/extensioncompiler.rb
+++ b/lib/rake/extensioncompiler.rb
@@ -39,7 +39,7 @@ module Rake
       paths = ENV['PATH'].split(File::PATH_SEPARATOR)
 
       # the pattern to look into (captures *nix and windows executables)
-      pattern = "i?86*mingw*gcc{,.*}"
+      pattern = "{mingw32-,i?86*mingw*}gcc{,.*}"
 
       @mingw_gcc_executable = paths.find do |path|
         # cleanup paths before globbing


### PR DESCRIPTION
Rake-compiler stopped working for me after the change e4f6c18, which disqualifies mingw32-gcc as a valid MinGW compiler.
I think "mingw32-gcc" should be a perfect name for a 32bit compiler rake-compiler is looking for. :smiley: 
