### PR TITLE
Fix test suite failure with Ruby 2.0.0.

### DIFF
--- a/spec/lib/rake/extensiontask_spec.rb
+++ b/spec/lib/rake/extensiontask_spec.rb
@@ -471,6 +471,7 @@ describe Rake::ExtensionTask do
       'rbconfig-1.9.1' => '/some/path/version/1.9.1/to/rbconfig.rb',
       'rbconfig-1.9.2' => '/some/path/version/1.9.1/to/rbconfig.rb',
       'rbconfig-1.9.3' => '/some/path/version/1.9.1/to/rbconfig.rb',
+      'rbconfig-2.0.0' => '/some/path/version/1.9.1/to/rbconfig.rb',
       'rbconfig-3.0.0' => '/some/fake/version/3.0.0/to/rbconfig.rb'
     }
   end


### PR DESCRIPTION
This prevents "no configuration section for specified version of Ruby (rbconfig-2.0.0)" and subsequent test errors, such as:

```
  1) Rake::ExtensionTask (tasks) (cross platform tasks) (cross for 'universal-unknown' platform) fake should chain fake task to Makefile generation
     Failure/Error: Rake::Task["tmp/universal-unknown/extension_one/#{@ruby_ver}/Makefile"].prerequisites.should include("tmp/universal-unknown/extension_one/#{@ruby_ver}/fake.rb")
       expected [] to include "tmp/universal-unknown/extension_one/2.0.0/fake.rb"
     # /usr/share/gems/gems/rspec-expectations-2.12.1/lib/rspec/expectations/fail_with.rb:33:in `fail_with'
     # /usr/share/gems/gems/rspec-expectations-2.12.1/lib/rspec/expectations/handler.rb:31:in `handle_matcher'
     # /usr/share/gems/gems/rspec-expectations-2.12.1/lib/rspec/expectations/syntax.rb:53:in `should'
     # /builddir/build/BUILD/rubygem-rake-compiler-0.8.2/usr/share/gems/gems/rake-compiler-0.8.2/spec/lib/rake/extensiontask_spec.rb:396:in `block (6 levels) in <top (required)>'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example.rb:114:in `instance_eval'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example.rb:114:in `block in run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example.rb:111:in `run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:388:in `block in run_examples'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:384:in `map'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:384:in `run_examples'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:369:in `run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `block in run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `map'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `block in run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `map'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `block in run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `map'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `block in run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `map'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/command_line.rb:28:in `map'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/command_line.rb:28:in `block in run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/reporter.rb:34:in `report'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/command_line.rb:25:in `run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/runner.rb:80:in `run'
     # /usr/share/gems/gems/rspec-core-2.12.2/lib/rspec/core/runner.rb:17:in `block in autorun'
```
