### PR TITLE
Re-support fat gem

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -122,11 +122,6 @@ Java extension should be preferred.
         include_dirs = ['.'].concat(@config_includes).uniq.join(File::PATH_SEPARATOR)
         cmd = [Gem.ruby, "-I#{include_dirs}"]
 
-        # if fake.rb is present, add to the command line
-        if t.prerequisites.include?("#{tmp_path}/fake.rb") then
-          cmd << '-rfake'
-        end
-
         # build a relative path to extconf script
         abs_tmp_path = (Pathname.new(Dir.pwd) + tmp_path).realpath
         abs_extconf = (Pathname.new(Dir.pwd) + extconf).realpath
@@ -308,7 +303,10 @@ Java extension should be preferred.
 
       # copy the file from the cross-ruby location
       file "#{tmp_path}/rbconfig.rb" => [rbconfig_file] do |t|
-        cp t.prerequisites.first, t.name
+        File.open(t.name, 'w') do |f|
+          f.write "require 'fake.rb'\n\n"
+          f.write File.read(t.prerequisites.first)
+        end
       end
 
       # copy mkmf from cross-ruby location


### PR DESCRIPTION
Ruby 1.9 bundles RubyGems and it is required automatically before
command line "-r" option. It breaks fake.rb trick. We cannot build fat
gem without fake.rb trick because building fat gem requires two or
more Rubies and fake.rb fakes Rubies.

/tmp/rbconfig.rb:

```
p :rbconfig

puts caller

module RbConfig
  Config = {}
end
```

/tmp/fake.rb:

```
p :fake
```

Command:

```
% cd /tmp
% ruby -v -I . -r fake -e ''
ruby 1.9.3p194 (2012-04-20 revision 35410) [x86_64-linux]
:rbconfig
/usr/lib/ruby/1.9.1/rubygems.rb:31:in `require'
/usr/lib/ruby/1.9.1/rubygems.rb:31:in `<top (required)>'
<internal:gem_prelude>:1:in `require'
<internal:gem_prelude>:1:in `<compiled>'
:fake
```

The command output shows fake.rb that is used to change RUBY_PLATFORM,
RUBY_VERSION and so on in rake-compiler is required after
rbconfig.rb. And rbconfig.rb is required from RubyGems.

fake.rb should be required before rbconfig.rb because rbconfig.rb uses
RUBY_VERSION. So this change puts 'require "fake.rb"' into
rbconfig.rb. It ensures that fake.rb is evaluated before rbconfig.rb
body is evaluated.
