### PR TITLE
Patch Ruby 1.8.7's mkmf.rb so it works with newer Ruby.

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -380,6 +380,17 @@ Java extension should be preferred.
       # copy mkmf from cross-ruby location
       file "#{tmp_path}/mkmf.rb" => [mkmf_file] do |t|
         cp t.prerequisites.first, t.name
+        if ruby_ver < "1.9" && "1.9" <= RUBY_VERSION
+          File.open(t.name, 'r+t') do |f|
+            content = f.read
+            content.sub!(/^(      break )\*(defaults)$/, '\\1\\2.first')
+            content.sub!(/^(    return )\*(defaults)$/, '\\1\\2.first')
+            content.sub!(/^(  mfile\.)print( configuration\(srcprefix\))$/, '\\1puts\\2')
+            f.rewind
+            f.write content
+            f.truncate(f.tell)
+          end
+        end
       end
 
       # genearte fake.rb for different ruby versions


### PR DESCRIPTION
Currently rake-compiler cannot cross-build an extension for Ruby 1.8.7 if it is run with Ruby 1.9 or later, because Ruby 1.8.7's mkmf.rb has forward compatibility problems:

```
knu@daemon*master% rake cross compile RUBY_CC_VERSION=1.8.7:1.9.3:2.0.0
cd tmp/x86-mingw32/unf_ext/1.8.7
/home/knu/arch/freebsd9/mach/amd64/ruby_2_0_0/bin/ruby -I. ../../../../ext/unf_ext/extconf.rb
/home/knu/src/github/ruby-unf_ext/tmp/x86-mingw32/unf_ext/1.8.7/mkmf.rb:1166:in `block in dir_config': undefined method `+' for nil:NilClass (NoMethodError)
        from /home/knu/src/github/ruby-unf_ext/tmp/x86-mingw32/unf_ext/1.8.7/mkmf.rb:1166:in `collect'
        from /home/knu/src/github/ruby-unf_ext/tmp/x86-mingw32/unf_ext/1.8.7/mkmf.rb:1166:in `dir_config'
        from /home/knu/src/github/ruby-unf_ext/tmp/x86-mingw32/unf_ext/1.8.7/mkmf.rb:1736:in `init_mkmf'
        from /home/knu/src/github/ruby-unf_ext/tmp/x86-mingw32/unf_ext/1.8.7/mkmf.rb:1761:in `<top (required)>'
        from /home/knu/arch/freebsd9/mach/amd64/ruby_2_0_0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
        from /home/knu/arch/freebsd9/mach/amd64/ruby_2_0_0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
        from ../../../../ext/unf_ext/extconf.rb:1:in `<main>'
rake aborted!
Command failed with status (1): [/home/knu/arch/freebsd9/mach/amd64/ruby_2_...]

Tasks: TOP => compile => compile:x86-mingw32 => compile:unf_ext:x86-mingw32 => copy:unf_ext:x86-mingw32:1.8.7 => tmp/x86-mingw32/unf_ext/1.8.7/unf_ext.so => tmp/x86-mingw32/unf_ext/1.8.7/Makefile
(See full trace by running task with --trace)
```

The attached commit fixes the problem by patching mkmf.rb. (This cannot be done by monkey patching because the error occurs during `require 'mkmf'`)
