### PR TITLE
Pre-load resolver library before faking.

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -482,6 +482,11 @@ Java extension should be preferred.
 
     def fake_rb(platform, version)
       <<-FAKE_RB
+        # Pre-load resolver library before faking, in order to avoid error
+        # "cannot load such file -- win32/resolv" when it is required later on.
+        # See also: https://github.com/tjschuck/rake-compiler-dev-box/issues/5
+        require 'resolv'
+
         class Object
           remove_const :RUBY_PLATFORM
           remove_const :RUBY_VERSION


### PR DESCRIPTION
This is to avoid error `cannot load such file -- win32/resolv` when it is required later on.

This solves issue https://github.com/tjschuck/rake-compiler-dev-box/issues/5

Important: The patch will not have any effect, until the `fake.rb` files in the build directory were deleted (or alternatively the full build directory cleared). Only then rake-compiler installs a version of `fake.rb` with this fix.
