### PR TITLE
added configuration for Ruby 2.1 support in spec

### DIFF
--- a/spec/lib/rake/extensiontask_spec.rb
+++ b/spec/lib/rake/extensiontask_spec.rb
@@ -491,7 +491,10 @@ describe Rake::ExtensionTask do
       'rbconfig-universal-unknown-2.0.0' => '/some/path/version/2.0.0/to/rbconfig.rb',
       'rbconfig-i386-mingw32-2.0.0' => '/some/path/version/2.0.0/to/rbconfig.rb',
       'rbconfig-x64-mingw32-2.0.0' => '/some/path/version/2.0.0/to/rbconfig.rb',
-      'rbconfig-x64-mingw32-3.0.0' => '/some/fake/version/3.0.0/to/rbconfig.rb'
+      'rbconfig-x64-mingw32-3.0.0' => '/some/fake/version/3.0.0/to/rbconfig.rb',
+      'rbconfig-i386-mingw32-2.1.2' => '/some/path/version/2.1.2/to/rbconfig.rb',
+      'rbconfig-universal-unknown-2.1.2' => '/some/path/version/2.1.2/to/rbconfig.rb',
+      'rbconfig-universal-known-2.1.2' => '/some/path/version/2.1.2/to/rbconfig.rb'
     }
   end
 


### PR DESCRIPTION
add Ruby 2.1 support in Spec tests

Debian bugs:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=746084
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=747723
