### PR TITLE
Improve git ignore config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
-.*.sw[pon]
-.ruby-version
-.rvmrc
-coverage
-doc/api
-Gemfile.lock
-pkg
-tmp
+/.ruby-version
+/.rvmrc
+/Gemfile.lock
+/coverage/
+/doc/api/
+/pkg/
+/tmp/


### PR DESCRIPTION
* Remove patterns belonging to global git ignore config;
* Specify full paths where possible;
* Mark directories as such with a trailing slash.

Would you be interested by such a change? I think it's better for
occasional contributors so they wouldn't be surprised by unexpected
behavior caused by an entry existing while they think it can't.

I can update if my change in the present form is incorrect.
