### PR TITLE
Change make program detection with `make' fallback

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -6,6 +6,11 @@ require "rubygems/package_task"
 
 module Rake
   class ExtensionTask < BaseExtensionTask
+    MAKE_PROGRAM_DETECTION = {
+      'gmake -v'        => 'gmake',
+      'make -v'         => 'make',
+      'command -v make' => 'make'
+    }.freeze
 
     attr_accessor :config_script
     attr_accessor :cross_compile
@@ -453,9 +458,9 @@ Java extension should be preferred.
           if RUBY_PLATFORM =~ /mswin/ then
             'nmake'
           else
-            ENV['MAKE'] || %w[gmake make].find { |c|
-              system("#{c} -v >> #{dev_null} 2>&1")
-            }
+            ENV['MAKE'] || MAKE_PROGRAM_DETECTION.find { |test, program|
+              system("#{test} >> #{dev_null} 2>&1")
+            }[1]
           end
       end
 


### PR DESCRIPTION
On my platform (FreeBSD), make program is simply `make`, and is
provided in the base install. However, I have to run
`MAKE=make rake compile` to avoid this kind of error:

    cd tmp/amd64-freebsd10/uh/2.2.1
    rake aborted!
    Couldn't find a suitable `make` tool. Use `MAKE` env to set an alternative.
    /.../.gem/ruby/22/gems/rake-compiler-0.9.5/lib/rake/extensiontask.rb:465:in `make'
    /.../.gem/ruby/22/gems/rake-compiler-0.9.5/lib/rake/extensiontask.rb:155:in `block (2 levels) in define_compile_tasks'
    /.../.gem/ruby/22/gems/rake-compiler-0.9.5/lib/rake/extensiontask.rb:154:in `block in define_compile_tasks'
    Tasks: TOP => compile => compile:amd64-freebsd10 => compile:uh:amd64-freebsd10 => copy:uh:amd64-freebsd10:2.2.1 => tmp/amd64-freebsd10/uh/2.2.1/uh.so
    (See full trace by running task with --trace)
    zsh: exit 1

I'm not sure if the change I propose is acceptable, but I can work on
alternatives that would satisfy other requirements. I didn't found
some tests (cucumber or rspec) related to the original behavior
concerning make program detection, should I add some on the original
behavior before this change, and after update this one with new tests?
