### PR TITLE
Update cucumber POSIX step for *BSD platforms

### DIFF
--- a/features/step_definitions/cross_compilation.rb
+++ b/features/step_definitions/cross_compilation.rb
@@ -1,6 +1,6 @@
-# Naive way of looking into platforms, please include others like FreeBSD?
+# Naive way of looking into platforms
 Given %r{^I'm running a POSIX operating system$} do
-  unless RbConfig::CONFIG['host_os'] =~ /linux|darwin/ then
+  unless RbConfig::CONFIG['host_os'] =~ /linux|darwin|bsd|dragonfly/ then
     raise Cucumber::Pending.new("You need a POSIX operating system, no cheating ;-)")
   end
 end


### PR DESCRIPTION
Cucumber test suite includes a "I'm running a POSIX operating system"
step. This change updates the host OS test to support most BSD
platforms, it should work with: FreeBSD, NetBSD, OpenBSD,
DragonFly BSD and maybe others.

Popular ruby projects like listen uses the same kind of regular
expression pattern:
https://github.com/guard/listen/blob/master/Gemfile#L11
