### PR TITLE
Don't build extensions for cross rubies.

### DIFF
--- a/tasks/bin/cross-ruby.rake
+++ b/tasks/bin/cross-ruby.rake
@@ -135,8 +135,7 @@ file "#{USER_HOME}/builds/#{MINGW_HOST}/#{RUBY_CC_VERSION}/Makefile" => ["#{USER
     "--build=#{RUBY_BUILD}",
     '--enable-shared',
     '--disable-install-doc',
-    '--without-tk',
-    '--without-tcl'
+    '--with-ext='
   ]
 
   # Force Winsock2 for Ruby 1.8, 1.9 defaults to it


### PR DESCRIPTION
The extension libraries of the ruby stdlib are not required to cross build binary gems. They just waste compilation time and disk storage.

The option "--with-ext=" is supported since ruby-1.9.2, but ruby-1.8.7 just ignores this option. I verified that the cross ruby-build and building binary gems succeeds with the following ruby versions:

``` sh
    rake-compiler cross-ruby VERSION=1.8.7-p374 HOST=i586-mingw32msvc
    rake-compiler cross-ruby VERSION=1.9.3-p550 HOST=i586-mingw32msvc
    rake-compiler cross-ruby VERSION=2.0.0-p645 HOST=i686-w64-mingw32
    rake-compiler cross-ruby VERSION=2.0.0-p645 HOST=x86_64-w64-mingw32
    rake-compiler cross-ruby VERSION=2.1.6 HOST=i686-w64-mingw32
    rake-compiler cross-ruby VERSION=2.1.6 HOST=x86_64-w64-mingw32
    rake-compiler cross-ruby VERSION=2.2.2 HOST=i686-w64-mingw32
    rake-compiler cross-ruby VERSION=2.2.2 HOST=x86_64-w64-mingw32
```

I already use this patch as part of the [rake-compiler-dock](https://github.com/larskanis/rake-compiler-dock) .