### PR TITLE
Replace rake-compiler-dev-box in favour of rake-compiler-dock

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -234,10 +234,11 @@ different 'host' OS's.
 
 ==== The Easy Way
 
-Use rake-compiler-dev-box, a virtual machine provisioned with all the necessary
-build tools.  With one command, you can cross-compile and package your gem into
-native, Java, and Windows fat binaries (with 1.8, 1.9, and 2.0 support).  See
-https://github.com/tjschuck/rake-compiler-dev-box for more information.
+Use rake-compiler-dock, a gem that makes use of a virtual machine provisioned with
+all the necessary build tools.  You can add a task to your Rakefile, that
+cross-compiles and packages your gem into Windows fat binaries (with 1.8 to 2.2
+and x86/x64 support). See https://github.com/larskanis/rake-compiler-dock for more
+information.
 
 ==== The Manual Way
 


### PR DESCRIPTION
[Rake-compiler-dev-box](https://github.com/tjschuck/rake-compiler-dev-box) is no longer maintained by it's author. Although there are several forks, each adding changes for a given target project, it is generally more extensive to set up and to integrate. Vagrant images are built on the users computer and are not versioned. Moreover the vagrant images are mutable, so that every build can make persistent changes to the box. In the end this makes each and every rake-compiler-dev-box rather unique.

[Rake-compiler-dock](https://github.com/larskanis/rake-compiler-dock) comes as a gem and solves these issues by using Docker instead of Vagrant. That makes rake-compiler-dock faster and more reliable. It also provides a simple API that let's the user integrate the cross build into the Rakefile of the given project. In addition, it is also usable on Windows.

Although JRuby was included in the first step, it didn't make much sense. JRuby can easily be installed native on each target platform. So now, rake-compiler-dock focuses on Windows binary gems only. This fits to the given README section, too.

To sum up, I wouldn't recommend rake-compiler-dev-box to users of rake-compiler, any longer.