### PR TITLE
Fix install destination with directory prefixes

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -110,8 +110,16 @@ Rerun `rake` under MRI Ruby 1.8.x/1.9.x to cross/native compile.
       # platform usage
       platf = for_platform || platform
 
+      # target_prefix
+      if @name.include? '/'
+        target_prefix = File.dirname(name)
+        target_prefix[0,0] = '/'
+      else
+        target_prefix = ''
+      end
+
       # lib_path
-      lib_path = lib_dir
+      lib_path = "#{lib_dir}#{target_prefix}"
 
       # tmp_path
       tmp_path = "#{@tmp_dir}/#{platf}/#{@name}/#{ruby_ver}"

--- a/spec/lib/rake/extensiontask_spec.rb
+++ b/spec/lib/rake/extensiontask_spec.rb
@@ -279,6 +279,36 @@ describe Rake::ExtensionTask do
         @ruby_ver = RUBY_VERSION
       end
 
+      context 'compile' do
+        it 'should define as task' do
+          Rake::Task.task_defined?('compile').should be_true
+        end
+
+        it "should depend on 'compile:{platform}'" do
+          Rake::Task['compile'].prerequisites.should include("compile:#{@platform}")
+        end
+      end
+
+      context 'compile:prefix1/prefix2/extension_one' do
+        it 'should define as task' do
+          Rake::Task.task_defined?('compile:prefix1/prefix2/extension_one').should be_true
+        end
+
+        it "should depend on 'compile:prefix1/prefix2/extension_one:{platform}'" do
+          Rake::Task['compile:prefix1/prefix2/extension_one'].prerequisites.should include("compile:prefix1/prefix2/extension_one:#{@platform}")
+        end
+      end
+
+      context 'lib/prefix1/prefix2/extension_one.{so,bundle}' do
+        it 'should define as task' do
+          Rake::Task.task_defined?("lib/prefix1/prefix2/#{@ext_bin}").should be_true
+        end
+
+        it "should depend on 'copy:prefix1/prefix2/extension_one:{platform}:{ruby_ver}'" do
+          Rake::Task["lib/prefix1/prefix2/#{@ext_bin}"].prerequisites.should include("copy:prefix1/prefix2/extension_one:#{@platform}:#{@ruby_ver}")
+        end
+      end
+
       context 'tmp/{platform}/prefix1/prefix2/extension_one/{ruby_ver}/extension_one.{so,bundle}' do
         it 'should define as task' do
           Rake::Task.task_defined?("tmp/#{@platform}/prefix1/prefix2/extension_one/#{@ruby_ver}/#{@ext_bin}").should be_true


### PR DESCRIPTION
In addition to #128, the install destination should be fixed to make sure the directory prefixes are preserved.

For example, when the extension name is `foo/bar`, the target shared library `bar.so` will be installed in `lib` directory in the current master branch in spite of it should be in `lib/foo`.

Moreover, I've added some examples for the case with directory prefixes.