### PR TITLE
Accept symbol name in extension task

### DIFF
--- a/lib/rake/baseextensiontask.rb
+++ b/lib/rake/baseextensiontask.rb
@@ -46,6 +46,7 @@ module Rake
 
     def define
       fail "Extension name must be provided." if @name.nil?
+      @name = @name.to_s
 
       define_compile_tasks
     end

--- a/spec/lib/rake/extensiontask_spec.rb
+++ b/spec/lib/rake/extensiontask_spec.rb
@@ -17,6 +17,11 @@ describe Rake::ExtensionTask do
         ext.name.should == 'extension_one'
       end
 
+      it 'should allow symbol as extension name assignation' do
+        ext = Rake::ExtensionTask.new(:extension_one)
+        ext.name.should == 'extension_one'
+      end
+
       it 'should allow string as extension name using block assignation' do
         ext = Rake::ExtensionTask.new do |ext|
           ext.name = 'extension_two'


### PR DESCRIPTION
Since I write rake's normal task name in Symbol, I've used Symbol for the argument of `Rake::ExtensionTask.new` until rake-compiler v0.9.7. But rake-compiler v0.9.8 raises an error with such case in https://github.com/rake-compiler/rake-compiler/blob/v0.9.8/lib/rake/extensiontask.rb#L115.

I propose to accept Symbol for `Rake::ExtensionTask`'s name like `Rake::Task` https://github.com/ruby/rake/blob/v11.1.2/lib/rake/task.rb#L95.