### PR TITLE
Fix using wrong alt separator when cross compiling

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -533,7 +533,7 @@ Java extension should be preferred.
           RUBY_VERSION = "#{version}"
           RUBY_DESCRIPTION = "ruby \#{RUBY_VERSION} (\#{RUBY_RELEASE_DATE}) [\#{RUBY_PLATFORM}]"
         end
-        if RUBY_PLATFORM =~ /mswin|bccwin|mingw/
+        if '#{RUBY_PLATFORM}' =~ /mswin|bccwin|mingw/
           class File
             remove_const :ALT_SEPARATOR
             ALT_SEPARATOR = "\\\\"


### PR DESCRIPTION
As stated in the commit, the alt separator should be based on host compilation platform, not cross compilation target platform. This fixes not being able to cross compile for windows, from windows, via intermediate linux build system (eg, using rake-compiler-dock).

Fixes https://github.com/rails-sqlserver/tiny_tds/issues/331