### PR TITLE
Regard C++ sources as source_files

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -18,7 +18,7 @@ module Rake
     def init(name = nil, gem_spec = nil)
       super
       @config_script = 'extconf.rb'
-      @source_pattern = "*.c"
+      @source_pattern = "*.{c,cc,cpp}"
       @compiled_pattern = "*.{o,obj,so,bundle,dSYM}"
       @cross_compile = false
       @cross_config_options = []

--- a/spec/lib/rake/extensiontask_spec.rb
+++ b/spec/lib/rake/extensiontask_spec.rb
@@ -77,8 +77,8 @@ describe Rake::ExtensionTask do
       @ext.lib_dir.should == 'lib'
     end
 
-    it 'should look for C files pattern (.c)' do
-      @ext.source_pattern.should == "*.c"
+    it 'should look for C/C++ files pattern (.c,.cc,.cpp)' do
+      @ext.source_pattern.should == "*.{c,cc,cpp}"
     end
 
     it 'should have no configuration options preset to delegate' do


### PR DESCRIPTION
While we can write CRuby's extension in C++, `rake compile` does not hook `make` by `*.cc` file changes. When I develop C++ extension, I want to compile it incrementally by `rake compile`. 

So I changed rake-compiler to regard `*.cc` (and `*.cpp` for some users) as `source_files`.