### PR TITLE
Use 'libdir' of rbconfig to get jruby classpath

### DIFF
--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -211,11 +211,14 @@ execute the Rake compilation task using the JRuby interpreter.
         end
       end
       unless jruby_cpath
-        jruby_cpath = ENV['JRUBY_PARENT_CLASSPATH'] || ENV['JRUBY_HOME'] &&
-          Dir.glob("#{File.expand_path(ENV['JRUBY_HOME'])}/lib/*.jar").
-            join(File::PATH_SEPARATOR)
+        require 'rbconfig'
+        libdir = RbConfig::CONFIG['libdir']
+        if libdir.start_with? "classpath:"
+          raise 'Cannot build with jruby-complete'
+        end
+        jruby_cpath = libdir && File.join(libdir, "jruby.jar")
       end
-      raise "JRUBY_HOME or JRUBY_PARENT_CLASSPATH are not set" unless jruby_cpath
+      raise "'libdir' not set" unless jruby_cpath
       jruby_cpath += File::PATH_SEPARATOR + args.join(File::PATH_SEPARATOR) unless args.empty?
       jruby_cpath ? "-cp \"#{jruby_cpath}\"" : ""
     end

--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -216,9 +216,8 @@ execute the Rake compilation task using the JRuby interpreter.
         if libdir.start_with? "classpath:"
           raise 'Cannot build with jruby-complete'
         end
-        jruby_cpath = libdir && File.join(libdir, "jruby.jar")
+        jruby_cpath = File.join(libdir, "jruby.jar")
       end
-      raise "'libdir' not set" unless jruby_cpath
       jruby_cpath += File::PATH_SEPARATOR + args.join(File::PATH_SEPARATOR) unless args.empty?
       jruby_cpath ? "-cp \"#{jruby_cpath}\"" : ""
     end


### PR DESCRIPTION
`classpath` is not set above java 9. `jruby.jar` is found in `<jruby-home>/lib/` directory and that path can be retrieved from `RbConfig::Config['libdir']` without `JRUBY_HOME` set.

Reference: https://github.com/jruby/activerecord-jdbc-adapter/commit/995be701d58f58a34bc0d1448c9cd54f9fcd9e48