### PR TITLE
Update source & target version defaults to 6

### DIFF
--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -29,8 +29,8 @@ module Rake
       @classpath      = nil
       @java_compiling = nil
       @debug          = false
-      @source_version = '1.5'
-      @target_version = '1.5'
+      @source_version = '1.6'
+      @target_version = '1.6'
     end
 
     def define


### PR DESCRIPTION
Source & Target version 5 are no longer supported for java8 and later. refer https://github.com/ruby-concurrency/concurrent-ruby/issues/747#issuecomment-416230078