### PR TITLE
Fix cross-platform compilation for Java extensions

### DIFF
--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -213,15 +213,9 @@ execute the Rake compilation task using the JRuby interpreter.
         end
       end
 
-      unless jruby_cpath
-        libdir = RbConfig::CONFIG['libdir']
-        if libdir.start_with? "classpath:"
-          raise 'Cannot build with jruby-complete'
-        end
-        candidate = File.join(libdir, "jruby.jar")
-        jruby_cpath = candidate if File.exist? candidate
-      end
-
+      # jruby_cpath might not be present from Java-9 onwards as it removes
+      # sun.boot.class.path. Check if JRUBY_HOME is set as env variable and try
+      # to find jruby.jar under JRUBY_HOME
       unless jruby_cpath
         jruby_home = ENV['JRUBY_HOME']
         if jruby_home
@@ -230,7 +224,21 @@ execute the Rake compilation task using the JRuby interpreter.
         end
       end
 
-      raise "jruby.jar path not found" unless jruby_cpath
+      # JRUBY_HOME is not necessarily set in JRuby-9.x
+      # Find the libdir from RbConfig::CONFIG and find jruby.jar under the
+      # found lib path
+      unless jruby_cpath
+        libdir = RbConfig::CONFIG['libdir']
+        if libdir.start_with? "uri:classloader:"
+          raise 'Cannot build with jruby-complete from Java 9 onwards'
+        end
+        candidate = File.join(libdir, "jruby.jar")
+        jruby_cpath = candidate if File.exist? candidate
+      end
+
+      unless jruby_cpath
+        raise "Could not find jruby.jar. Please set JRUBY_HOME or Use jruby in rvm"
+      end
 
       jruby_cpath += File::PATH_SEPARATOR + args.join(File::PATH_SEPARATOR) unless args.empty?
       jruby_cpath ? "-cp \"#{jruby_cpath}\"" : ""

--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -212,13 +212,26 @@ execute the Rake compilation task using the JRuby interpreter.
         rescue => e
         end
       end
+
       unless jruby_cpath
         libdir = RbConfig::CONFIG['libdir']
         if libdir.start_with? "classpath:"
           raise 'Cannot build with jruby-complete'
         end
-        jruby_cpath = File.join(libdir, "jruby.jar")
+        candidate = File.join(libdir, "jruby.jar")
+        jruby_cpath = candidate if File.exist? candidate
       end
+
+      unless jruby_cpath
+        jruby_home = ENV['JRUBY_HOME']
+        if jruby_home
+          candidate = File.join(jruby_home, 'lib', 'jruby.jar')
+          jruby_cpath = candidate if File.exist? candidate
+        end
+      end
+
+      raise "jruby.jar path not found" unless jruby_cpath
+
       jruby_cpath += File::PATH_SEPARATOR + args.join(File::PATH_SEPARATOR) unless args.empty?
       jruby_cpath ? "-cp \"#{jruby_cpath}\"" : ""
     end


### PR DESCRIPTION
Using `libdir` provided by `RbConfig` to compile java extension from MRI
breaks as it can't find `jruby.jar` under `lib` directory. Added a check
on file existence if the path is taken from RbConfig and if it doesn't
exist, check for the path which is set in environment JRUBY_HOME to find
correct `jruby.jar`.

Raise the error to abort compilation if `jruby.jar` is not found.