### PR TITLE
Gemspec: Drop EOL'd rubyforge_project directive

### DIFF
--- a/rake-compiler.gemspec
+++ b/rake-compiler.gemspec
@@ -44,7 +44,6 @@ Gem::Specification.new do |s|
 
   # project information
   s.homepage          = 'https://github.com/rake-compiler/rake-compiler'
-  s.rubyforge_project = 'rake-compiler'
   s.licenses          = ['MIT']
 
   # author and contributors


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.