### PR TITLE
Make lint options customizable

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,7 +1,9 @@
 === develop
 
 * Enhancements:
-  *
+  * Make customizable compiler Xlint option for JRuby native extension.
+    #118 [Patch by Hiroshi Hatake]
+    #158 [Patch by Stephen George]
 
 * Bugfixes:
   *

--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,11 @@
+=== develop
+
+* Enhancements:
+  *
+
+* Bugfixes:
+  *
+
 === 1.0.8 / 2019-09-21
 
 * Enhancements:

--- a/History.txt
+++ b/History.txt
@@ -1,9 +1,12 @@
 === develop
 
+* Changes:
+  * Use "-Xlint" option for JRuby native extension by default.
+    #158 [Patch by Stephen George]
+
 * Enhancements:
   * Make customizable compiler Xlint option for JRuby native extension.
     #118 [Patch by Hiroshi Hatake]
-    #158 [Patch by Stephen George]
 
 * Bugfixes:
   *

--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -39,7 +39,7 @@ module Rake
       @target_version = '1.6'
       @encoding       = nil
       @java_compiling = nil
-      @lint_option    = 'unchecked'
+      @lint_option    = nil
     end
 
     def define
@@ -102,7 +102,7 @@ execute the Rake compilation task using the JRuby interpreter.
         classpath_arg = java_classpath_arg(@classpath)
         debug_arg     = @debug ? '-g' : ''
 
-        sh "javac #{java_encoding_arg} #{java_extdirs_arg} -target #{@target_version} -source #{@source_version} -Xlint:#{@lint_option} #{debug_arg} #{classpath_arg} -d #{tmp_path} #{source_files.join(' ')}"
+        sh "javac #{java_encoding_arg} #{java_extdirs_arg} -target #{@target_version} -source #{@source_version} #{java_lint_arg @lint_option} #{debug_arg} #{classpath_arg} -d #{tmp_path} #{source_files.join(' ')}"
 
         # Checkpoint file
         touch "#{tmp_path}/.build"
@@ -258,5 +258,16 @@ execute the Rake compilation task using the JRuby interpreter.
       jruby_cpath ? "-cp \"#{jruby_cpath}\"" : ""
     end
 
+    #
+    # Convert a `-Xlint:___` linting option such as `deprecation` into a full javac argument, such as `-Xlint:deprecation`.
+    #
+    # @param [String]  lint_option  A `-Xlint:___` linting option such as `deprecation`, `all`, `none`, etc.
+    # @return [String]              Default: _Simply `-Xlint` is run, which enables recommended warnings.
+    #
+    def java_lint_arg(lint_option)
+      return '-Xlint' unless lint_option
+
+      "-Xlint:#{lint_option}"
+    end
   end
 end

--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -19,6 +19,9 @@ module Rake
 
     attr_accessor :encoding
 
+    # Specify lint option
+    attr_accessor :lint_option
+
     def platform
       @platform ||= 'java'
     end
@@ -36,6 +39,7 @@ module Rake
       @target_version = '1.6'
       @encoding       = nil
       @java_compiling = nil
+      @lint_option    = 'unchecked'
     end
 
     def define
@@ -98,7 +102,7 @@ execute the Rake compilation task using the JRuby interpreter.
         classpath_arg = java_classpath_arg(@classpath)
         debug_arg     = @debug ? '-g' : ''
 
-        sh "javac #{java_encoding_arg} #{java_extdirs_arg} -target #{@target_version} -source #{@source_version} -Xlint:unchecked #{debug_arg} #{classpath_arg} -d #{tmp_path} #{source_files.join(' ')}"
+        sh "javac #{java_encoding_arg} #{java_extdirs_arg} -target #{@target_version} -source #{@source_version} -Xlint:#{@lint_option} #{debug_arg} #{classpath_arg} -d #{tmp_path} #{source_files.join(' ')}"
 
         # Checkpoint file
         touch "#{tmp_path}/.build"

--- a/spec/lib/rake/javaextensiontask_spec.rb
+++ b/spec/lib/rake/javaextensiontask_spec.rb
@@ -76,6 +76,10 @@ describe Rake::JavaExtensionTask do
       @ext.config_options.should be_empty
     end
 
+    it 'lint option should be "unchecked"' do
+      @ext.lint_option.should == 'unchecked'
+    end
+
     it 'should default to Java platform' do
       @ext.platform.should == 'java'
     end
@@ -164,6 +168,19 @@ describe Rake::JavaExtensionTask do
         it "should include 'tmp'" do
           CLOBBER.should include('tmp')
         end
+      end
+    end
+
+    context 'A custom extension' do
+      let(:extension) do
+        Rake::JavaExtensionTask.new('extension_two') do |ext|
+          ext.lint_option = lint_option
+        end
+      end
+      let(:lint_option) { 'deprecated'.freeze }
+
+      it 'should honor the lint option' do
+        (extension.lint_option).should eq lint_option
       end
     end
   end

--- a/spec/lib/rake/javaextensiontask_spec.rb
+++ b/spec/lib/rake/javaextensiontask_spec.rb
@@ -79,6 +79,7 @@ describe Rake::JavaExtensionTask do
     it 'should default to Java platform' do
       @ext.platform.should == 'java'
     end
+  end
 
   context '(tasks)' do
     before :each do
@@ -164,7 +165,6 @@ describe Rake::JavaExtensionTask do
           CLOBBER.should include('tmp')
         end
       end
-    end
     end
   end
   private

--- a/spec/lib/rake/javaextensiontask_spec.rb
+++ b/spec/lib/rake/javaextensiontask_spec.rb
@@ -76,8 +76,8 @@ describe Rake::JavaExtensionTask do
       @ext.config_options.should be_empty
     end
 
-    it 'lint option should be "unchecked"' do
-      @ext.lint_option.should == 'unchecked'
+    it 'should have no lint option preset to delegate' do
+      @ext.lint_option.should be_falsey
     end
 
     it 'should default to Java platform' do
@@ -174,13 +174,26 @@ describe Rake::JavaExtensionTask do
     context 'A custom extension' do
       let(:extension) do
         Rake::JavaExtensionTask.new('extension_two') do |ext|
-          ext.lint_option = lint_option
+          ext.lint_option = lint_option if lint_option
         end
       end
-      let(:lint_option) { 'deprecated'.freeze }
 
-      it 'should honor the lint option' do
-        (extension.lint_option).should eq lint_option
+      context 'without a specified lint option' do
+        let(:lint_option) { nil }
+
+        it 'should honor the lint option' do
+          (extension.lint_option).should be_falsey
+          (extension.send :java_lint_arg, extension.lint_option).should eq '-Xlint'
+        end
+      end
+
+      context "with a specified lint option of 'deprecated'" do
+        let(:lint_option) { 'deprecated'.freeze }
+
+        it 'should honor the lint option' do
+          (extension.lint_option).should eq lint_option
+          (extension.send :java_lint_arg, extension.lint_option).should eq '-Xlint:deprecated'
+        end
       end
     end
   end


### PR DESCRIPTION
This rebases/revives PR #118 by Hiroshi Hatake to allow a custom -Xlint:____ option to be specified for JRuby native extensions.  This is particularly important for those who want to:
* Highlight major deprecations with `-Xlint:deprecation`.
* Silence all linting warnings with `-Xlint:unchecked`.

Note that provided no customized linting option, this PR proposes that `-Xlint` be included by default.  This tells the javac compiler to output all _recommended_ warnings.

Additionally, this PR exhaustively lists in the README ALL supported configuration options.  In order to specify this in a formatted table, I had to convert README.rdoc to README.md.