### PR TITLE
Update default ruby version for native tasks

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -254,7 +254,7 @@ Java extension should be preferred.
           spec.platform = Gem::Platform.new(platf)
 
           # set ruby version constraints
-          ruby_versions = @ruby_versions_per_platform[platf] || []
+          ruby_versions = @ruby_versions_per_platform[platf] || [ruby_ver]
           sorted_ruby_versions = ruby_versions.sort_by do |ruby_version|
             ruby_version.split(".").collect(&:to_i)
           end


### PR DESCRIPTION
When trying to build a native (non cross-compiled) gem I ran into #156.
To fix this, I updated the default for `ruby_versions` to `[ruby_ver]`
(which is set to `RUBY_VERSION`). This shouldn't affect cross-compiled
work since `ruby_versions` will be set to
`@ruby_versions_per_platform[platf]` when set.