### PR TITLE
Allow parallel builds of cross rubies

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -377,7 +377,10 @@ Java extension should be preferred.
         return
       end
 
-      config_file = YAML.load_file(config_path)
+      config_file = File.open(config_path) do |fd|
+        fd.flock(File::LOCK_SH)
+        YAML.load(fd.read)
+      end
 
       # tmp_path
       tmp_path = "#{@tmp_dir}/#{for_platform}/#{@name}/#{ruby_ver}"


### PR DESCRIPTION
This is used in rake-compiler-dock: https://github.com/rake-compiler/rake-compiler-dock/blob/master/Dockerfile.mri#L85-L92 Without the `parallel` tool cross ruby builds take ages.

Download and extraction of sources can not run in parallel, since the sources are used for multiple targets. Therefore this part can now be separately executed by
```
  rake-compiler prepare-sources RUBY_CC_VERSION=...
```

Afterwards multiple cross rubies can be built in parallel by
```
  rake-compiler cross-ruby RUBY_CC_VERSION=... HOST=...
```

Access to `config.yml` must be synchronized, when running in parallel, which is done per File#flock .