### PR TITLE
Extend mingw search pattern to find x86_64 gcc

### DIFF
--- a/lib/rake/extensioncompiler.rb
+++ b/lib/rake/extensioncompiler.rb
@@ -37,7 +37,7 @@ module Rake
       paths = ENV['PATH'].split(File::PATH_SEPARATOR)
 
       # the pattern to look into (captures *nix and windows executables)
-      pattern = "{mingw32-,i?86*mingw*}gcc{,.*}"
+      pattern = "{mingw32-,i?86*mingw*,x86*mingw*}gcc{,.*}"
 
       @mingw_gcc_executable = paths.find do |path|
         # cleanup paths before globbing


### PR DESCRIPTION
The previous pattern only recognized 32 bit compiler versions.

Cross compiler names are usually `i686-w64-mingw32-gcc` and `x86_64-w64-mingw32-gcc`.

Background is, that I'll probably split the single  docker image of rake-compiler-dock into target specific versions. And the `x64-mingw32` version currently fails, since it doesn't contain a recognized mingw compiler.
