### PR TITLE
Strip cross built shared library files while linking

### DIFF
--- a/tasks/bin/cross-ruby.rake
+++ b/tasks/bin/cross-ruby.rake
@@ -113,7 +113,8 @@ file "#{build_dir}/Makefile" => [build_dir, source_dir] do |t|
     "--build=#{RUBY_BUILD}",
     '--enable-shared',
     '--disable-install-doc',
-    '--with-ext='
+    '--with-ext=',
+    'LDFLAGS=-pipe -s',
   ]
 
   # Force Winsock2 for Ruby 1.8, 1.9 defaults to it


### PR DESCRIPTION
The .so files of extensions are often manually stripped after compilation per task in a Rakefile. This is done to reduce gem size and because debug information in release binaries isn't particular useful.

This manual step can be avoided, if the cross ruby version is built with stripping enabled. Compatibility is ensured, since stripping files a second time doesn't make a difference.