### PR TITLE
Fix determining of ruby versions in "rake native gem"

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -234,6 +234,10 @@ Java extension should be preferred.
       # lib_path
       lib_path = lib_dir
 
+      # Update compiled platform/version combinations
+      ruby_versions = (@ruby_versions_per_platform[platf] ||= [])
+      ruby_versions << ruby_ver
+
       # create 'native:gem_name' and chain it to 'native' task
       unless Rake::Task.task_defined?("native:#{@gem_spec.name}:#{platf}")
         task "native:#{@gem_spec.name}:#{platf}" do |t|

--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -25,7 +25,8 @@ module Rake
       @cross_compiling = nil
       @no_native = (ENV["RAKE_EXTENSION_TASK_NO_NATIVE"] == "true")
       @config_includes = []
-      @ruby_versions_per_platform = {}
+      # Default to an empty list of ruby versions for each platform
+      @ruby_versions_per_platform = Hash.new { |h, k| h[k] = [] }
       @make = nil
     end
 
@@ -235,8 +236,7 @@ Java extension should be preferred.
       lib_path = lib_dir
 
       # Update compiled platform/version combinations
-      ruby_versions = (@ruby_versions_per_platform[platf] ||= [])
-      ruby_versions << ruby_ver
+      @ruby_versions_per_platform[platf] << ruby_ver
 
       # create 'native:gem_name' and chain it to 'native' task
       unless Rake::Task.task_defined?("native:#{@gem_spec.name}:#{platf}")
@@ -250,7 +250,7 @@ Java extension should be preferred.
           spec.platform = Gem::Platform.new(platf)
 
           # set ruby version constraints
-          ruby_versions = @ruby_versions_per_platform[platf] || []
+          ruby_versions = @ruby_versions_per_platform[platf]
           sorted_ruby_versions = ruby_versions.sort_by do |ruby_version|
             ruby_version.split(".").collect(&:to_i)
           end
@@ -353,8 +353,7 @@ Java extension should be preferred.
         end
 
         # Update cross compiled platform/version combinations
-        ruby_versions = (@ruby_versions_per_platform[for_platform] ||= [])
-        ruby_versions << version
+        @ruby_versions_per_platform[for_platform] << version
 
         define_cross_platform_tasks_with_version(for_platform, version)
 


### PR DESCRIPTION
"rake native gem" without "cross" didn't set the ruby version constraint.
Instead it failed with NoMethodError like so:
```
/ffi $ rake native gem
no configuration section for specified version of Ruby (rbconfig-i386-mingw32-2.6.3)
no configuration section for specified version of Ruby (rbconfig-x64-mingw32-2.6.3)
install -c build/x86_64-linux/ffi_c/2.6.3/ffi_c.so lib/ffi_c.so
cp build/x86_64-linux/ffi_c/2.6.3/ffi_c.so build/x86_64-linux/stage/lib/ffi_c.so
rake aborted!
NoMethodError: undefined method `split' for nil:NilClass
/home/lars/.rvm/gems/ruby-2.6.3/gems/rake-compiler-1.0.9/lib/rake/extensiontask.rb:515:in `ruby_api_version'
/home/lars/.rvm/gems/ruby-2.6.3/gems/rake-compiler-1.0.9/lib/rake/extensiontask.rb:262:in `block in define_native_tasks'
/home/lars/.rvm/gems/ruby-2.6.3/gems/rake-12.3.3/exe/rake:27:in `<top (required)>'
/home/lars/.rvm/gems/ruby-2.6.3/bin/ruby_executable_hooks:24:in `eval'
/home/lars/.rvm/gems/ruby-2.6.3/bin/ruby_executable_hooks:24:in `<main>'
Tasks: TOP => native => native:x86_64-linux => native:ffi:x86_64-linux
(See full trace by running task with --trace)
```