### PR TITLE
Fix ruby warning:

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -26,6 +26,7 @@ module Rake
       @no_native = false
       @config_includes = []
       @ruby_versions_per_platform = {}
+      @make = nil
     end
 
     def cross_platform


### PR DESCRIPTION
lib/rake/extensiontask.rb:471: warning: instance variable @make not initialized