### PR TITLE
Call cross_compiling block for native platform too

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -234,7 +234,7 @@ Java extension should be preferred.
       end
     end
 
-    def define_native_tasks(for_platform = nil, ruby_ver = RUBY_VERSION, callback = nil)
+    def define_native_tasks(for_platform = nil, ruby_ver = RUBY_VERSION)
       platf = for_platform || platform
 
       # tmp_path
@@ -280,7 +280,7 @@ Java extension should be preferred.
           spec.files += ext_files
 
           # expose gem specification for customization
-          callback.call(spec) if callback
+          @cross_compiling.call(spec) if @cross_compiling
 
           # Generate a package for this gem
           pkg = Gem::PackageTask.new(spec) do |p|
@@ -425,7 +425,7 @@ Java extension should be preferred.
 
       # now define native tasks for cross compiled files
       if @gem_spec && @gem_spec.platform == 'ruby' then
-        define_native_tasks(for_platform, ruby_ver, @cross_compiling)
+        define_native_tasks(for_platform, ruby_ver)
       end
 
       # create cross task


### PR DESCRIPTION
Currently the cross_compiling block isn't called when cross compiling for the build platform.
This is due to the fact that define_native_tasks() is called first for the build platform
and later on for the cross platforms. The task "native:<gemname>:<platform>" is [defined
only once](https://github.com/rake-compiler/rake-compiler/blob/a86722f002290b1c7b7b0edae6cdd624618e8153/lib/rake/extensiontask.rb#L247) and therefore only without the callback. The callback is therefore not called
for the cross platform that equals the build platform.

OMHO the root issue is that rake-compiler doesn't has a clear separation between
native and cross tasks. However I think calling cross_compiling for any binary gem
(native or cross) is a suitable workaround.

This fixes bug https://github.com/sparklemotion/nokogiri/issues/1991#issuecomment-592755871