### PR TITLE
Default to 1.7-level bytecode in Java build

### DIFF
--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -35,8 +35,8 @@ module Rake
       @source_pattern = '**/*.java'
       @classpath      = nil
       @debug          = false
-      @source_version = '1.6'
-      @target_version = '1.6'
+      @source_version = '1.7'
+      @target_version = '1.7'
       @encoding       = nil
       @java_compiling = nil
       @lint_option    = nil


### PR DESCRIPTION
rake-compiler defaults to source level and output bytecode version 1.6, corresponding to Java 1.6.

JRuby has not supported 1.6 since the release of JRuby 9.0, five years ago, when we started requiring Java 7.

This PR updates the default versions to "1.7" level for Java 7.

All current supported versions of JRuby require Java 8, but I'm ok with using 1.7 here for any 9.0 stragglers.