### PR TITLE
Don't mask out build env vars for cross-ruby

### DIFF
--- a/tasks/bin/cross-ruby.rake
+++ b/tasks/bin/cross-ruby.rake
@@ -46,7 +46,7 @@ RUBY_SOURCE = ENV['SOURCE']
 RUBY_BUILD = RbConfig::CONFIG["host"]
 
 # Unset any possible variable that might affect compilation
-["CC", "CXX", "CPPFLAGS", "LDFLAGS", "RUBYOPT"].each do |var|
+["RUBYOPT"].each do |var|
   ENV.delete(var)
 end
 
@@ -119,7 +119,6 @@ RUBY_CC_VERSIONS.split(":").each do |ruby_cc_version|
         '--enable-shared',
         '--disable-install-doc',
         '--with-ext=',
-        'LDFLAGS=-pipe -s',
       ]
 
       # Force Winsock2 for Ruby 1.8, 1.9 defaults to it


### PR DESCRIPTION
This was introduced in commit a7c113e580c1565000166f9967da82ff2ecdaeaa to avoid interference with host build. However it prohibits setting important flags for cross-build.

Also don't force 'LDFLAGS=-pipe -s' in configure, which doesn't work with `clang` compiler targeting MacOS. It can now be set externally.

Fixes #178