### PR TITLE
IronRuby has been a dead project for 10 years

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -46,15 +46,6 @@ module Rake
     end
 
     def define
-      if (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'ironruby')
-        warn_once <<-EOF
-WARNING: You're attempting to (cross-)compile C extensions from a platform
-(#{RUBY_ENGINE}) that does not support native extensions or mkmf.rb.
-Rerun `rake` under MRI Ruby 1.8.x/1.9.x to cross/native compile.
-        EOF
-        return
-      end
-
       super
 
       unless compiled_files.empty?


### PR DESCRIPTION
Iron Ruby was abandoned as a project by Microsoft in spring of 2011.  It only supports Ruby 1.8.6 and I am wondering if rake-compiler will even load on that last release.  Time to remove this warning saying they do not support native c-exts?