### PR TITLE
Avoid warning: assigned but unused variable - e

### DIFF
--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -237,7 +237,7 @@ execute the Rake compilation task using the JRuby interpreter.
           cpath  = Java::java.lang.System.getProperty('java.class.path').split(File::PATH_SEPARATOR)
           cpath += Java::java.lang.System.getProperty('sun.boot.class.path').split(File::PATH_SEPARATOR)
           jruby_cpath = cpath.compact.join(File::PATH_SEPARATOR)
-        rescue => e
+        rescue
         end
       end
 


### PR DESCRIPTION
This PR avoids a Ruby warning.

Seen at https://travis-ci.org/github/ruby-concurrency/concurrent-ruby/jobs/755324784#L277 