### PR TITLE
CI: Add Ruby 3.0 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,10 @@ jobs:
           - macos-latest
           - ubuntu-latest
         ruby:
-          - 2.5
-          - 2.6
-          - 2.7
+          - "2.5"
+          - "2.6"
+          - "2.7"
+          - "3.0"
           - head
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR **adds Ruby 3.0** to the build matrix in CI.

Got to 🟢 !


