### PR TITLE
Add `MAKEOPT` env to specify make options.

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -153,7 +153,7 @@ module Rake
       task "copy:#{@name}:#{platf}:#{ruby_ver}" => [lib_binary_dir_path, tmp_binary_path, "#{tmp_path}/Makefile"] do
         # install in lib for native platform only
         unless for_platform
-          sh "#{make} install", chdir: tmp_path
+          sh "#{make} #{make_opt} install", chdir: tmp_path
         end
       end
       # copy binary from temporary location to staging directory
@@ -174,7 +174,7 @@ Java extension should be preferred.
         warn_once(jruby_compile_msg) if defined?(JRUBY_VERSION)
 
         chdir tmp_path do
-          sh make
+          sh "#{make} #{make_opt}"
           if binary_path != File.basename(binary_path)
             cp File.basename(binary_path), binary_path
           end
@@ -510,6 +510,14 @@ Java extension should be preferred.
       end
 
       nil
+    end
+
+    def make_opt
+      unless @make_opt
+        @make_opt = ENV['MAKEOPT'] || ''
+      end
+
+      @make_opt
     end
 
     def compiled_files


### PR DESCRIPTION
I love to see the `rake-compiler` can have an environment variable to specify the `make` command options.

Because I want to compile `extconf.rb` with `make V=1 CFLAGS="..." CXXFLAGS="..."` to see the compiling command lines such as compiler flags and macros for just debugging. It makes us to easy to debug. For `CFLAGS` and `CXXFLAGS`, we can change the value by changing `$CFLAGS` and `$CXXFLAGS` such as in `extconf.rb`. But for `V`, it is hardcoded in Ruby's  [lib/mkmf.rb](https://github.com/ruby/ruby/blob/9f9045123efefbd11dd397b4d59596290765feec/lib/mkmf.rb#L1933).

Right now I have a resistance for setting `MAKE="make V=1 ..."` in `Rakefile` or `tasks/compile.rake`.
Because someone might use `gmake` or `nmake` rather than `make`.
https://github.com/rake-compiler/rake-compiler/blob/master/lib/rake/extensiontask.rb#L501

So, I think it's convenient to separate the current `MAKE` into `MAKE` and `MAKEOPT`.

The environment variable name `MAKEOPT` is inspired from `RUBYOPT` ([the document](https://www.tutorialspoint.com/ruby/ruby_environment_variables.htm)) in Ruby. 

What do you think?



