### PR TITLE
Set correct `required_ruby_version` when some `RUBY_CC_VERSION`s are missing

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -377,9 +377,6 @@ Java extension should be preferred.
           @lib_dir = "#{@lib_dir}/#{$1}"
         end
 
-        # Update cross compiled platform/version combinations
-        @ruby_versions_per_platform[for_platform] << version
-
         define_cross_platform_tasks_with_version(for_platform, version)
 
         # restore lib_dir

--- a/spec/lib/rake/extensiontask_spec.rb
+++ b/spec/lib/rake/extensiontask_spec.rb
@@ -456,14 +456,17 @@ describe Rake::ExtensionTask do
 
       it "should set required_ruby_version from RUBY_CC_VERSION, set platform, clear extensions but keep metadata" do
         platforms = ["x86-mingw32", "x64-mingw32"]
-        ruby_cc_versions = ["1.8.6", "2.1.10", "2.2.6", "2.3.3", "2.10.1"]
+        ruby_cc_versions = ["1.8.6", "2.1.10", "2.2.6", "2.3.3", "2.10.1", "2.11.0"]
         ENV["RUBY_CC_VERSION"] = ruby_cc_versions.join(":")
         config = Hash.new
         ruby_cc_versions.each do |ruby_cc_version|
           platforms.each do |platform|
+            unless platform == "x64-mingw32" && ruby_cc_version == "2.11.0"
+              rbconf = "/rubies/#{ruby_cc_version}/rbconfig.rb"
+            end
             allow(config).to receive(:[]).
               with("rbconfig-#{platform}-#{ruby_cc_version}").
-              and_return("/rubies/#{ruby_cc_version}/rbconfig.rb")
+              and_return(rbconf)
           end
         end
         allow(YAML).to receive(:load_file).and_return(config)
@@ -490,7 +493,7 @@ describe Rake::ExtensionTask do
         end
 
         expected_required_ruby_versions = [
-          Gem::Requirement.new([">= 1.8", "< 2.11.dev"]),
+          Gem::Requirement.new([">= 1.8", "< 2.12.dev"]),
           Gem::Requirement.new([">= 1.8", "< 2.11.dev"]),
         ]
         cross_specs.collect(&:required_ruby_version).should == expected_required_ruby_versions


### PR DESCRIPTION
The `required_ruby_version` was set twice, although one in `define_native_tasks` is enough.

The original commit that introduced automatic setting of `required_ruby_version` was https://github.com/rake-compiler/rake-compiler/commit/0dc23504cb03ed2fb3c506e1bb58af48d3851d1e . It detected the ruby version entirely based on `RUBY_CC_VERSION`. Later on there was commit https://github.com/rake-compiler/rake-compiler/commit/0dc23504cb03ed2fb3c506e1bb58af48d3851d1e which introduced setting the `required_ruby_version` for native but not cross gems and only for the active ruby versions. This made the first detection obsolete, but it wasn't deleted so far. This is fixed by this PR.

Fixes #198