### PR TITLE
Support --release option to build JRuby extension for older platforms

### DIFF
--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -110,15 +110,13 @@ execute the Rake compilation task using the JRuby interpreter.
 
         javac_command_line = [
           "javac",
-          "-target", @target_version,
-          "-source", @source_version,
+          java_target_arg,
           java_lint_arg,
           "-d", tmp_path,
         ]
         javac_command_line.concat(java_encoding_args)
         javac_command_line.concat(java_extdirs_args)
         javac_command_line.concat(java_classpath_args)
-        javac_command_line << "--release=#{@release}" if @release
         javac_command_line << "-g" if @debug
         javac_command_line.concat(source_files)
         sh(*javac_command_line)
@@ -210,6 +208,14 @@ execute the Rake compilation task using the JRuby interpreter.
 
       task 'java' do
         task 'compile' => 'compile:java'
+      end
+    end
+
+    def java_target_arg
+      if @release
+        "--release=#{@release}"
+      else
+        "-target #{@target_version} -source #{@source_version}"
       end
     end
 

--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -17,6 +17,9 @@ module Rake
     # Generate class files for specific VM version
     attr_accessor :target_version
 
+    # Compile for oldeer platform version
+    attr_accessor :release
+
     attr_accessor :encoding
 
     # Specify lint option
@@ -37,6 +40,7 @@ module Rake
       @debug          = false
       @source_version = '1.7'
       @target_version = '1.7'
+      @release        = nil
       @encoding       = nil
       @java_compiling = nil
       @lint_option    = nil
@@ -114,6 +118,7 @@ execute the Rake compilation task using the JRuby interpreter.
         javac_command_line.concat(java_encoding_args)
         javac_command_line.concat(java_extdirs_args)
         javac_command_line.concat(java_classpath_args)
+        javac_command_line << "--release=#{@release}" if @release
         javac_command_line << "-g" if @debug
         javac_command_line.concat(source_files)
         sh(*javac_command_line)

--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -110,7 +110,7 @@ execute the Rake compilation task using the JRuby interpreter.
 
         javac_command_line = [
           "javac",
-          java_target_arg,
+          *java_target_args,
           java_lint_arg,
           "-d", tmp_path,
         ]
@@ -211,11 +211,11 @@ execute the Rake compilation task using the JRuby interpreter.
       end
     end
 
-    def java_target_arg
+    def java_target_args
       if @release
-        "--release=#{@release}"
+        ["--release=#{@release}"]
       else
-        "-target #{@target_version} -source #{@source_version}"
+        ["-target", @target_version, "-source", @source_version]
       end
     end
 

--- a/spec/lib/rake/javaextensiontask_spec.rb
+++ b/spec/lib/rake/javaextensiontask_spec.rb
@@ -175,11 +175,13 @@ describe Rake::JavaExtensionTask do
       let(:extension) do
         Rake::JavaExtensionTask.new('extension_two') do |ext|
           ext.lint_option = lint_option if lint_option
+          ext.release = release if release
         end
       end
 
       context 'without a specified lint option' do
         let(:lint_option) { nil }
+        let(:release) { nil }
 
         it 'should honor the lint option' do
           (extension.lint_option).should be_falsey
@@ -189,10 +191,33 @@ describe Rake::JavaExtensionTask do
 
       context "with a specified lint option of 'deprecated'" do
         let(:lint_option) { 'deprecated'.freeze }
+        let(:release) { nil }
 
         it 'should honor the lint option' do
           (extension.lint_option).should eq lint_option
           (extension.send :java_lint_arg).should eq '-Xlint:deprecated'
+        end
+      end
+
+      context "without release option" do
+        let(:lint_option) { nil }
+        let(:release) { nil }
+
+        it 'should generate -target and -source build options' do
+          extension.target_version = "1.8"
+          extension.source_version = "1.8"
+          (extension.send :java_target_arg).should eq "-target 1.8 -source 1.8"
+        end
+      end
+
+      context "with release option" do
+        let(:lint_option) { nil }
+        let(:release) { '8' }
+
+        it 'should generate --release option even with target_version/source_version' do
+          extension.target_version = "1.8"
+          extension.source_version = "1.8"
+          (extension.send :java_target_arg).should eq "--release=8"
         end
       end
     end

--- a/spec/lib/rake/javaextensiontask_spec.rb
+++ b/spec/lib/rake/javaextensiontask_spec.rb
@@ -206,7 +206,7 @@ describe Rake::JavaExtensionTask do
         it 'should generate -target and -source build options' do
           extension.target_version = "1.8"
           extension.source_version = "1.8"
-          (extension.send :java_target_arg).should eq "-target 1.8 -source 1.8"
+          (extension.send :java_target_args).should eq ["-target", "1.8", "-source", "1.8"]
         end
       end
 
@@ -217,7 +217,7 @@ describe Rake::JavaExtensionTask do
         it 'should generate --release option even with target_version/source_version' do
           extension.target_version = "1.8"
           extension.source_version = "1.8"
-          (extension.send :java_target_arg).should eq "--release=8"
+          (extension.send :java_target_args).should eq ["--release=8"]
         end
       end
     end


### PR DESCRIPTION
Fixes #200 

The patch can solve the problem https://github.com/msgpack/msgpack-ruby/issues/239

Without this option (see `Method java/nio/ByteBuffer.clear:()Ljava/nio/ByteBuffer;` at 39):
```
$ javap -p -c -s -v -l -constants tmp/java/msgpack/org/msgpack/jruby/Encoder.class
(snip)
  private org.jruby.runtime.builtin.IRubyObject readRubyString();
    descriptor: ()Lorg/jruby/runtime/builtin/IRubyObject;
    flags: (0x0002) ACC_PRIVATE
    Code:
      stack=8, locals=2, args_size=1
         0: aload_0
         1: getfield      #15                 // Field runtime:Lorg/jruby/Ruby;
         4: new           #89                 // class org/jruby/util/ByteList
         7: dup
         8: aload_0
         9: getfield      #25                 // Field buffer:Ljava/nio/ByteBuffer;
        12: invokevirtual #78                 // Method java/nio/ByteBuffer.array:()[B
        15: iconst_0
        16: aload_0
        17: getfield      #25                 // Field buffer:Ljava/nio/ByteBuffer;
        20: invokevirtual #82                 // Method java/nio/ByteBuffer.position:()I
        23: aload_0
        24: getfield      #41                 // Field binaryEncoding:Lorg/jcodings/Encoding;
        27: iconst_0
        28: invokespecial #91                 // Method org/jruby/util/ByteList."<init>":([BIILorg/jcodings/Encoding;Z)V
        31: invokevirtual #94                 // Method org/jruby/Ruby.newString:(Lorg/jruby/util/ByteList;)Lorg/jruby/RubyString;
        34: astore_1
        35: aload_0
        36: getfield      #25                 // Field buffer:Ljava/nio/ByteBuffer;
        39: invokevirtual #98                 // Method java/nio/ByteBuffer.clear:()Ljava/nio/ByteBuffer;
        42: pop
        43: aload_1
        44: areturn
      LineNumberTable:
        line 69: 0
        line 70: 35
        line 71: 43
(snip)
```

With this option (see `Method java/nio/ByteBuffer.clear:()Ljava/nio/Buffer;` at 39 as well)
```
  private org.jruby.runtime.builtin.IRubyObject readRubyString();
    descriptor: ()Lorg/jruby/runtime/builtin/IRubyObject;
    flags: (0x0002) ACC_PRIVATE
    Code:
      stack=8, locals=2, args_size=1
         0: aload_0
         1: getfield      #15                 // Field runtime:Lorg/jruby/Ruby;
         4: new           #89                 // class org/jruby/util/ByteList
         7: dup
         8: aload_0
         9: getfield      #25                 // Field buffer:Ljava/nio/ByteBuffer;
        12: invokevirtual #78                 // Method java/nio/ByteBuffer.array:()[B
        15: iconst_0
        16: aload_0
        17: getfield      #25                 // Field buffer:Ljava/nio/ByteBuffer;
        20: invokevirtual #82                 // Method java/nio/ByteBuffer.position:()I
        23: aload_0
        24: getfield      #41                 // Field binaryEncoding:Lorg/jcodings/Encoding;
        27: iconst_0
        28: invokespecial #91                 // Method org/jruby/util/ByteList."<init>":([BIILorg/jcodings/Encoding;Z)V
        31: invokevirtual #94                 // Method org/jruby/Ruby.newString:(Lorg/jruby/util/ByteList;)Lorg/jruby/RubyString;
        34: astore_1
        35: aload_0
        36: getfield      #25                 // Field buffer:Ljava/nio/ByteBuffer;
        39: invokevirtual #98                 // Method java/nio/ByteBuffer.clear:()Ljava/nio/Buffer;
        42: pop
        43: aload_1
        44: areturn
      LineNumberTable:
        line 69: 0
        line 70: 35
        line 71: 43
```