### PR TITLE
Add support for RubyGems 3.3.21 or later

### DIFF
--- a/lib/rake/baseextensiontask.rb
+++ b/lib/rake/baseextensiontask.rb
@@ -5,6 +5,8 @@ require 'rbconfig'
 
 require 'pathname'
 
+require_relative "compiler_config"
+
 module Rake
   class BaseExtensionTask < TaskLib
 

--- a/lib/rake/compiler_config.rb
+++ b/lib/rake/compiler_config.rb
@@ -1,0 +1,12 @@
+module Rake
+  class CompilerConfig
+    def initialize(config_path)
+      require "yaml"
+      @config = YAML.load_file(config_path)
+    end
+
+    def find(ruby_version, gem_platform)
+      @config["rbconfig-#{gem_platform}-#{ruby_version}"]
+    end
+  end
+end

--- a/lib/rake/compiler_config.rb
+++ b/lib/rake/compiler_config.rb
@@ -6,7 +6,33 @@ module Rake
     end
 
     def find(ruby_version, gem_platform)
-      @config["rbconfig-#{gem_platform}-#{ruby_version}"]
+      gem_platform = Gem::Platform.new(gem_platform)
+
+      @config.each do |config_name, config_location|
+        # There are two variations we might find in the rake-compiler config.yml
+        #
+        # 1. config_name: rbconfig-x86_64-linux-3.0.0
+        #    runtime_platform_name: x86_64-linux
+        #    runtime_version: 3.0.0
+        #
+        # 2. config_name: rbconfig-x86_64-linux-gnu-3.0.0
+        #    runtime_platform_name: x86_64-linux-gnu
+        #    runtime_version: 3.0.0
+        #
+        # With rubygems < 3.3.21, both variations will be present (two entries pointing at the same
+        # installation).
+        #
+        # With rubygems >= 3.3.21, only the second variation will be present.
+        runtime_platform_name = config_name.split("-")[1..-2].join("-")
+        runtime_version = config_name.split("-").last
+        runtime_platform = Gem::Platform.new(runtime_platform_name)
+
+        if (ruby_version == runtime_version) && (gem_platform =~ runtime_platform)
+          return config_location
+        end
+      end
+
+      nil
     end
   end
 end

--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -393,8 +393,11 @@ Java extension should be preferred.
         return
       end
 
-      require "yaml"
-      config_file = YAML.load_file(config_path)
+      rbconfig_file = Rake::CompilerConfig.new(config_path).find(ruby_ver, for_platform)
+      unless rbconfig_file
+        warn "no configuration section for specified version of Ruby (rbconfig-#{for_platform}-#{ruby_ver})"
+        return
+      end
 
       # tmp_path
       tmp_path = "#{@tmp_dir}/#{for_platform}/#{@name}/#{ruby_ver}"
@@ -404,11 +407,6 @@ Java extension should be preferred.
 
       # lib_binary_path
       lib_binary_path = "#{lib_path}/#{File.basename(binary(for_platform))}"
-
-      unless rbconfig_file = config_file["rbconfig-#{for_platform}-#{ruby_ver}"] then
-        warn "no configuration section for specified version of Ruby (rbconfig-#{for_platform}-#{ruby_ver})"
-        return
-      end
 
       # mkmf
       mkmf_file = File.expand_path(File.join(File.dirname(rbconfig_file), '..', 'mkmf.rb'))

--- a/spec/lib/rake/compiler_config_spec.rb
+++ b/spec/lib/rake/compiler_config_spec.rb
@@ -27,4 +27,28 @@ describe Rake::CompilerConfig do
     expect(cc.find("2.7.0", "x86_64-linux")).to be_nil
     expect(cc.find("3.1.0", "arm64-linux")).to be_nil
   end
+
+  it "returns the matching config for inexact platform match" do
+    cc = Rake::CompilerConfig.new(config_file(<<~CONFIG))
+      ---
+      rbconfig-x86_64-linux-gnu-3.0.0: "/path/to/aaa/rbconfig.rb"
+      rbconfig-x86_64-linux-musl-3.1.0: "/path/to/bbb/rbconfig.rb"
+    CONFIG
+
+    expect(cc.find("3.0.0", "x86_64-linux")).to eq("/path/to/aaa/rbconfig.rb")
+    expect(cc.find("3.1.0", "x86_64-linux")).to eq("/path/to/bbb/rbconfig.rb")
+  end
+
+  it "does not match the other way around" do
+    if Gem::Version.new(Gem::VERSION) < Gem::Version.new("3.3.21")
+      skip "rubygems 3.3.21+ only"
+    end
+
+    cc = Rake::CompilerConfig.new(config_file(<<~CONFIG))
+      ---
+      rbconfig-x86_64-linux-3.1.0: "/path/to/bbb/rbconfig.rb"
+    CONFIG
+
+    expect(cc.find("3.1.0", "x86_64-linux-musl")).to be_nil
+  end
 end

--- a/spec/lib/rake/compiler_config_spec.rb
+++ b/spec/lib/rake/compiler_config_spec.rb
@@ -1,0 +1,30 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+require 'rake/extensiontask'
+require 'rbconfig'
+require 'tempfile'
+
+describe Rake::CompilerConfig do
+  def config_file(contents)
+    Tempfile.new.tap do |tf|
+      tf.write(contents)
+      tf.close
+    end
+  end
+
+  it "returns the matching config for exact platform match" do
+    cc = Rake::CompilerConfig.new(config_file(<<~CONFIG))
+      ---
+      rbconfig-x86_64-linux-3.0.0: "/path/to/aaa/rbconfig.rb"
+      rbconfig-x86_64-darwin-3.1.0: "/path/to/bbb/rbconfig.rb"
+      rbconfig-x86_64-linux-3.1.0: "/path/to/ccc/rbconfig.rb"
+    CONFIG
+
+    expect(cc.find("3.0.0", "x86_64-linux")).to eq("/path/to/aaa/rbconfig.rb")
+    expect(cc.find("3.1.0", "x86_64-darwin")).to eq("/path/to/bbb/rbconfig.rb")
+    expect(cc.find("3.1.0", "x86_64-linux")).to eq("/path/to/ccc/rbconfig.rb")
+
+    expect(cc.find("2.7.0", "x86_64-linux")).to be_nil
+    expect(cc.find("3.1.0", "arm64-linux")).to be_nil
+  end
+end


### PR DESCRIPTION
Since Rubygems 3.3.21, the Gem::Platform name always contains the library version for gnu platforms. So where the rake-compiler config entries previously were:

```yaml
---
rbconfig-x86_64-linux-gnu-2.7.0: "/usr/local/rake-compiler/ruby/x86_64-redhat-linux/ruby-2.7.0/lib/ruby/2.7.0/x86_64-linux-gnu/rbconfig.rb"
rbconfig-x86_64-linux-2.7.0: "/usr/local/rake-compiler/ruby/x86_64-redhat-linux/ruby-2.7.0/lib/ruby/2.7.0/x86_64-linux-gnu/rbconfig.rb"
```

with later versions of rubygems, it is only

```yaml
---
rbconfig-x86_64-linux-gnu-2.7.0: "/usr/local/rake-compiler/ruby/x86_64-redhat-linux/ruby-2.7.0/lib/ruby/2.7.0/x86_64-linux-gnu/rbconfig.rb"
```

This means that the current way of finding a matching runtime, by doing a string comparison on the config keys, is no longer appropriate. This is causing failing builds downstream in `rake-compiler-dock`.

This PR:

- extracts a new CompilerConfig class to encapsulate the logic
- uses `Gem::Platform#=~` to tell if the gem platform matches the runtime platform
