### PR TITLE
baseextensiontask: provide an API to allow for dynamic sources

### DIFF
--- a/lib/rake/baseextensiontask.rb
+++ b/lib/rake/baseextensiontask.rb
@@ -18,6 +18,7 @@ module Rake
     attr_accessor :config_options
     attr_accessor :source_pattern
     attr_accessor :extra_options
+    attr_accessor :extra_sources
     attr_writer :platform
 
     def platform
@@ -41,6 +42,7 @@ module Rake
       end
       @config_options = []
       @extra_options = ARGV.select { |i| i =~ /\A--?/ }
+      @extra_sources = FileList[]
     end
 
     def define
@@ -71,7 +73,7 @@ module Rake
     end
 
     def source_files
-      FileList["#{@ext_dir}/#{@source_pattern}"]
+      FileList["#{@ext_dir}/#{@source_pattern}"] + @extra_sources
     end
 
     def warn_once(message)

--- a/spec/lib/rake/extensiontask_spec.rb
+++ b/spec/lib/rake/extensiontask_spec.rb
@@ -58,6 +58,15 @@ describe Rake::ExtensionTask do
         end
         ext.platform.should == 'universal-foo-bar-10.5'
       end
+
+      it 'should allow extra sources to be added' do
+        ext = Rake::ExtensionTask.new('extension_one') do |ext|
+          ext.extra_sources << 'extra.c'
+        end
+        ext.extra_sources.should include('extra.c')
+        # Private API between the base task and the extension task
+        ext.send(:source_files).should include('extra.c')
+      end
     end
   end
 


### PR DESCRIPTION
If a build wishes to generate some of the extension source files then the pattern input is insufficient. Provide a place to stash an additional FileList that will then become a dependency of the compile tasks.

Example:

```ruby
file 'ext/libfoo/generated.c' do |t|
  open(t.name, 'w+) { |f| f << '#include <foo.h>' }
end

Rake::ExtensionTask.new('foo') do |ext|
  ext.extra_sources << 'generated.c'
end
```