### PR TITLE
Don't use --release flag on Java 8

### DIFF
--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -212,7 +212,7 @@ execute the Rake compilation task using the JRuby interpreter.
     end
 
     def java_target_args
-      if @release
+      if @release && release_flag_supported?
         ["--release=#{@release}"]
       else
         ["-target", @target_version, "-source", @source_version]
@@ -302,6 +302,12 @@ execute the Rake compilation task using the JRuby interpreter.
       return '-Xlint' unless @lint_option
 
       "-Xlint:#{@lint_option}"
+    end
+
+    def release_flag_supported?
+      return true unless RUBY_PLATFORM =~ /java/
+      
+      Gem::Version.new(Java::java.lang.System.getProperty('java.version')) >= Gem::Version.new("9")
     end
   end
 end


### PR DESCRIPTION
this allows using
```
  Rake::JavaExtensionTask.new("name", gemspec) do |ext|
    ext.release = '8'
  end
```
on Java 8 (for building the gem), because the flag is available since Java 9, see https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html

this flag is for backward compatibility, so it's safe to just skip it if we can't use it.

relates to https://github.com/puma/puma/pull/3109 https://github.com/socketry/nio4r/pull/292