### PR TITLE
drop ruby < 2.5 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "rake"
+gem 'rake'
 
 group :development do
-  gem "rspec",    "~> 3.0"
-  gem "cucumber", "~> 2.0"
+  gem 'cucumber', '~> 2.0'
+  gem 'rspec',    '~> 3.0'
 end

--- a/bin/rake-compiler
+++ b/bin/rake-compiler
@@ -18,7 +18,7 @@ end
 Rake.application.init('rake-compiler')
 
 # Load the already cooked tasks ;-)
-load File.join(File.dirname(__FILE__), %w{.. tasks bin cross-ruby.rake})
+load File.join(File.dirname(__FILE__), %w[.. tasks bin cross-ruby.rake])
 
 # delegate control to Rake
 Rake.application.top_level

--- a/features/step_definitions/compilation.rb
+++ b/features/step_definitions/compilation.rb
@@ -1,66 +1,66 @@
-Given /^a extension named '(.*)'$/ do |extension_name|
+Given(/^a extension named '(.*)'$/) do |extension_name|
   generate_extension_task_for extension_name
   generate_source_code_for extension_name
 end
 
-Given /^a extension cross-compilable '(.*)'$/ do |extension_name|
+Given(/^a extension cross-compilable '(.*)'$/) do |extension_name|
   generate_cross_compile_extension_task_for extension_name
   generate_source_code_for extension_name
 end
 
-Given /^a extension Java-compilable '(.*)'$/ do |extension_name|
+Given(/^a extension Java-compilable '(.*)'$/) do |extension_name|
   generate_java_compile_extension_task_for extension_name
   generate_java_source_code_for extension_name
 end
 
-Given /^a extension '(.*)' multi cross\-compilable$/ do |extension_name|
+Given(/^a extension '(.*)' multi cross-compilable$/) do |extension_name|
   generate_multi_cross_compile_extension_task_for extension_name
   generate_source_code_for extension_name
 end
 
-Given /^a extension '(.*)' with forced platform '(.*)'$/ do |extension_name, forced_platform|
+Given(/^a extension '(.*)' with forced platform '(.*)'$/) do |extension_name, forced_platform|
   generate_extension_task_for extension_name, forced_platform
   generate_source_code_for extension_name
 end
 
-Given /^that all my source files are in place$/ do
-  step "a safe project directory"
+Given(/^that all my source files are in place$/) do
+  step 'a safe project directory'
   step "a extension cross-compilable 'extension_one'"
 end
 
-Given /^that all my Java source files are in place$/ do
-  step "a safe project directory"
+Given(/^that all my Java source files are in place$/) do
+  step 'a safe project directory'
   step "a extension Java-compilable 'extension_one'"
 end
 
-Given /^that my gem source is all in place$/ do
-  step "a safe project directory"
+Given(/^that my gem source is all in place$/) do
+  step 'a safe project directory'
   step "a gem named 'gem_abc'"
   step "a extension cross-compilable 'extension_one'"
 end
 
-Given /^that my JRuby gem source is all in place$/ do
-  step "a safe project directory"
+Given(/^that my JRuby gem source is all in place$/) do
+  step 'a safe project directory'
   step "a gem named 'gem_abc'"
   step "a extension Java-compilable 'extension_one'"
 end
 
-Given /^that my gem source is all in place to target two platforms$/ do
-  step "a safe project directory"
+Given(/^that my gem source is all in place to target two platforms$/) do
+  step 'a safe project directory'
   step "a gem named 'gem_abc'"
   step "a extension 'extension_one' multi cross-compilable"
 end
 
-Given /^not changed any file since$/ do
+Given(/^not changed any file since$/) do
   # don't do anything, that's the purpose of this step!
 end
 
-When /^touching '(.*)' file of extension '(.*)'$/ do |file, extension_name|
+When(/^touching '(.*)' file of extension '(.*)'$/) do |file, extension_name|
   Kernel.sleep 1
   FileUtils.touch "ext/#{extension_name}/#{file}"
 end
 
-Then /^binary extension '(.*)' (do|do not) exist in '(.*)'$/ do |extension_name, condition, folder|
+Then(/^binary extension '(.*)' (do|do not) exist in '(.*)'$/) do |extension_name, condition, folder|
   ext_for_platform = File.join(folder, "#{extension_name}.#{RbConfig::CONFIG['DLEXT']}")
   if condition == 'do'
     File.exist?(ext_for_platform).should be_true

--- a/features/step_definitions/cross_compilation.rb
+++ b/features/step_definitions/cross_compilation.rb
@@ -1,24 +1,24 @@
 # Naive way of looking into platforms
-Given %r{^I'm running a POSIX operating system$} do
-  unless RbConfig::CONFIG['host_os'] =~ /linux|darwin|bsd|dragonfly/ then
-    raise Cucumber::Pending.new("You need a POSIX operating system, no cheating ;-)")
+Given(/^I'm running a POSIX operating system$/) do
+  unless /linux|darwin|bsd|dragonfly/.match?(RbConfig::CONFIG['host_os'])
+    raise Cucumber::Pending, 'You need a POSIX operating system, no cheating ;-)'
   end
 end
 
-Given %r{^I've installed cross compile toolchain$} do
-  unless search_path(%w(i586-mingw32msvc-gcc i386-mingw32-gcc i686-w64-mingw32-gcc))
+Given(/^I've installed cross compile toolchain$/) do
+  unless search_path(%w[i586-mingw32msvc-gcc i386-mingw32-gcc i686-w64-mingw32-gcc])
     pending 'Cannot locate suitable compiler in the PATH.'
   end
 end
 
-Then /^binaries for platform '(.*)' get generated$/ do |platform|
+Then(/^binaries for platform '(.*)' get generated$/) do |platform|
   ext = binary_extension(platform)
 
   ext_for_platform = Dir.glob("tmp/#{platform}/**/*.#{ext}")
   ext_for_platform.should_not be_empty
 end
 
-Then /^binaries for platform '(.*)' version '(.*)' get copied$/ do |platform, version|
+Then(/^binaries for platform '(.*)' version '(.*)' get copied$/) do |platform, version|
   lib_path = "lib/#{version}"
   ext = binary_extension(platform)
 

--- a/features/step_definitions/execution.rb
+++ b/features/step_definitions/execution.rb
@@ -4,7 +4,7 @@
 #  / on JRuby/.match(step_arg) != nil
 # end
 
-Given %r{^I've already successfully executed rake task '(.*)'(| on JRuby)$} do |task_name, on_jruby|
+Given(/^I've already successfully executed rake task '(.*)'(| on JRuby)$/) do |task_name, on_jruby|
   rake_cmd = "rake #{task_name}"
   rake_cmd = 'jruby -S ' << rake_cmd if on_jruby == ' on JRuby'
   emptyness = `#{rake_cmd} 2>&1`
@@ -14,7 +14,7 @@ Given %r{^I've already successfully executed rake task '(.*)'(| on JRuby)$} do |
   end
 end
 
-When /^rake task '(.*)' is invoked(| on JRuby)$/ do |task_name, on_jruby|
+When(/^rake task '(.*)' is invoked(| on JRuby)$/) do |task_name, on_jruby|
   @output ||= {}
   @result ||= {}
   rake_cmd = "rake #{task_name}"
@@ -23,30 +23,28 @@ When /^rake task '(.*)' is invoked(| on JRuby)$/ do |task_name, on_jruby|
   @result[task_name] = $?.success?
 end
 
-Then /^rake task '(.*)' succeeded$/ do |task_name|
-  if @result.nil? || !@result.include?(task_name) then
-    raise "The task #{task_name} should be invoked first."
+Then(/^rake task '(.*)' succeeded$/) do |task_name|
+  raise "The task #{task_name} should be invoked first." if @result.nil? || !@result.include?(task_name)
+
+
+  @result[task_name].should be_true
+end
+
+Then(/^rake task '(.*)' should fail$/) do |task_name|
+  raise "The task #{task_name} should be invoked first." if @result.nil? || !@result.include?(task_name)
+
+
+  @result[task_name].should be_false
+end
+
+Then(%r{^output of rake task '(.*)' (contains|do not contain) /(.*)/$}) do |task_name, condition, regex|
+  if condition == 'contains'
+    @output[task_name].should match(/#{regex}/)
   else
-    @result[task_name].should be_true
+    @output[task_name].should_not match(/#{regex}/)
   end
 end
 
-Then /^rake task '(.*)' should fail$/ do |task_name|
-  if @result.nil? || !@result.include?(task_name) then
-    raise "The task #{task_name} should be invoked first."
-  else
-    @result[task_name].should be_false
-  end
-end
-
-Then /^output of rake task '(.*)' (contains|do not contain) \/(.*)\/$/ do |task_name, condition, regex|
-  if condition == 'contains' then
-    @output[task_name].should match(%r(#{regex}))
-  else
-    @output[task_name].should_not match(%r(#{regex}))
-  end
-end
-
-Then /^output of rake task '(.*)' warns$/ do |task_name, warning|
+Then(/^output of rake task '(.*)' warns$/) do |task_name, warning|
   @output[task_name].should include(warning)
 end

--- a/features/step_definitions/folders.rb
+++ b/features/step_definitions/folders.rb
@@ -1,4 +1,4 @@
-Given /^a safe project directory$/ do
+Given(/^a safe project directory$/) do
   # step back to ROOT
   Dir.chdir ROOT_PATH
   tmp_name = "project.#{Process.pid}"
@@ -10,23 +10,23 @@ Given /^a safe project directory$/ do
   generate_scaffold_structure
 end
 
-Given /^'(.*)' folder (exist|is deleted)$/ do |folder, condition|
+Given(/^'(.*)' folder (exist|is deleted)$/) do |folder, condition|
   case condition
-    when 'exist'
-      raise "Folder #{folder} do not exist" unless File.exist?(folder) && File.directory?(folder)
-    when 'is deleted'
-      FileUtils.rm_rf folder
+  when 'exist'
+    raise "Folder #{folder} do not exist" unless File.exist?(folder) && File.directory?(folder)
+  when 'is deleted'
+    FileUtils.rm_rf folder
   end
 end
 
-Then /^'(.*)' folder is created$/ do |folder|
+Then(/^'(.*)' folder is created$/) do |folder|
   File.directory?(folder).should be_true
 end
 
-Then /^'(.*)' folder do not exist$/ do |folder|
+Then(/^'(.*)' folder do not exist$/) do |folder|
   File.directory?(folder).should_not be_true
 end
 
-Then /^no left over from '(.*)' remains in '(.*)'$/ do |name, folder|
+Then(/^no left over from '(.*)' remains in '(.*)'$/) do |name, folder|
   Dir.glob("#{folder}/**/#{name}/#{RUBY_VERSION}").should be_empty
 end

--- a/features/step_definitions/gem.rb
+++ b/features/step_definitions/gem.rb
@@ -1,16 +1,16 @@
-Given /^a gem named '(.*)'$/ do |gem_name|
+Given(/^a gem named '(.*)'$/) do |gem_name|
   generate_gem_task gem_name
 end
 
-Then /^ruby gem for '(.*)' version '(.*)' do exist in '(.*)'$/ do |name, version, folder|
+Then(/^ruby gem for '(.*)' version '(.*)' do exist in '(.*)'$/) do |name, version, folder|
   File.exist?(gem_file(folder, name, version)).should be_true
 end
 
-Then /^binary gem for '(.*)' version '(.*)' do exist in '(.*)'$/ do |name, version, folder|
+Then(/^binary gem for '(.*)' version '(.*)' do exist in '(.*)'$/) do |name, version, folder|
   File.exist?(gem_file_platform(folder, name, version)).should be_true
 end
 
-Then /^a gem for '(.*)' version '(.*)' platform '(.*)' do exist in '(.*)'$/ do |name, version, platform, folder|
+Then(/^a gem for '(.*)' version '(.*)' platform '(.*)' do exist in '(.*)'$/) do |name, version, platform, folder|
   File.exist?(gem_file_platform(folder, name, version, platform)).should be_true
 
   # unpack the Gem and check what's inside!
@@ -24,7 +24,7 @@ Then /^a gem for '(.*)' version '(.*)' platform '(.*)' do exist in '(.*)'$/ do |
   files.flatten.uniq.should_not be_empty
 end
 
-Then /^gem for platform '(.*)' get generated$/ do |platform|
+Then(/^gem for platform '(.*)' get generated$/) do |platform|
   step "a gem for 'gem_abc' version '0.1.0' platform '#{platform}' do exist in 'pkg'"
 end
 
@@ -34,13 +34,13 @@ end
 
 def gem_file_platform(folder, name, version, platform = nil)
   file = "#{folder}/#{name}-#{version}"
-  file << "-" << (platform || Gem::Platform.new(RUBY_PLATFORM).to_s)
-  file << ".gem"
+  file << '-' << (platform || Gem::Platform.new(RUBY_PLATFORM).to_s)
+  file << '.gem'
   file
 end
 
 def unpacked_gem_dir_platform(folder, name, version, platform = nil)
   file = "#{folder}/#{name}-#{version}"
-  file << "-" << (platform || Gem::Platform.new(RUBY_PLATFORM).to_s)
+  file << '-' << (platform || Gem::Platform.new(RUBY_PLATFORM).to_s)
   file
 end

--- a/features/step_definitions/java_compilation.rb
+++ b/features/step_definitions/java_compilation.rb
@@ -1,7 +1,8 @@
-Given %r{^I've installed the Java Development Kit$} do
-  pending('Cannot locate suitable Java compiler (the Java Development Kit) in the PATH.') unless search_path(%w(javac javac.exe))
+Given(/^I've installed the Java Development Kit$/) do
+  pending('Cannot locate suitable Java compiler (the Java Development Kit) in the PATH.') unless search_path(%w[javac
+                                                                                                                javac.exe])
 end
 
-Given %r{^I've installed JRuby$} do
-  pending('Cannot locate a JRuby installation in the PATH.') unless search_path(%w(jruby jruby.exe jruby.bat))
+Given(/^I've installed JRuby$/) do
+  pending('Cannot locate a JRuby installation in the PATH.') unless search_path(%w[jruby jruby.exe jruby.bat])
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,4 +7,4 @@ ROOT_PATH = File.expand_path(File.join(File.dirname(__FILE__), '../..'))
 
 # get rid of Bundler environment polution
 defined?(Bundler) and
-  ENV.delete("RUBYOPT")
+  ENV.delete('RUBYOPT')

--- a/features/support/file_template_helpers.rb
+++ b/features/support/file_template_helpers.rb
@@ -1,137 +1,136 @@
 module FileTemplateHelpers
   def template_rakefile
-    <<-EOF
-# add rake-compiler lib dir to the LOAD_PATH
-$LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), '../..', 'lib'))
+    <<~EOF
+      # add rake-compiler lib dir to the LOAD_PATH
+      $LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), '../..', 'lib'))
 
-require 'rubygems'
-require 'rake'
+      require 'rubygems'
+      require 'rake'
 
-# load rakefile extensions (tasks)
-Dir['tasks/*.rake'].each { |f| import f }
-EOF
+      # load rakefile extensions (tasks)
+      Dir['tasks/*.rake'].each { |f| import f }
+    EOF
   end
 
   def template_rake_gemspec(gem_name)
-    <<-EOF
-require 'rubygems/package_task'
-SPEC = Gem::Specification.new do |s|
-  s.name = "#{gem_name}"
-  s.version = "0.1.0"
-  s.summary = "#{gem_name} test gem for rake-compiler"
-  s.description = "#{gem_name} is a fake gem for testing under rake-compiler"
+    <<~EOF
+      require 'rubygems/package_task'
+      SPEC = Gem::Specification.new do |s|
+        s.name = "#{gem_name}"
+        s.version = "0.1.0"
+        s.summary = "#{gem_name} test gem for rake-compiler"
+        s.description = "#{gem_name} is a fake gem for testing under rake-compiler"
 
-  s.files = FileList["ext/**/*.{rb,c,h}", "Rakefile", "tasks/*.rake", "lib/**/*.rb"]
+        s.files = FileList["ext/**/*.{rb,c,h}", "Rakefile", "tasks/*.rake", "lib/**/*.rb"]
 
-  s.extensions = FileList["ext/**/extconf.rb"]
+        s.extensions = FileList["ext/**/extconf.rb"]
 
-  s.homepage = 'http://github.com/luislavena/rake-compiler'
-  s.rubyforge_project = 'TODO'
+        s.homepage = 'http://github.com/luislavena/rake-compiler'
+        s.rubyforge_project = 'TODO'
 
-  s.authors = ["Luis Lavena"]
-  s.email = ["luislavena@gmail.com"]
-end
+        s.authors = ["Luis Lavena"]
+        s.email = ["luislavena@gmail.com"]
+      end
 
-Gem::PackageTask.new(SPEC) do |pkg|
-  pkg.need_zip = false
-  pkg.need_tar = false
-end
-EOF
+      Gem::PackageTask.new(SPEC) do |pkg|
+        pkg.need_zip = false
+        pkg.need_tar = false
+      end
+    EOF
   end
 
   def template_rake_extension(extension_name, gem_spec = nil)
-    <<-EOF
-require 'rake/extensiontask'
-Rake::ExtensionTask.new("#{extension_name}"#{', SPEC' if gem_spec})
-EOF
+    <<~EOF
+      require 'rake/extensiontask'
+      Rake::ExtensionTask.new("#{extension_name}"#{', SPEC' if gem_spec})
+    EOF
   end
 
   def template_rake_extension_with_platform(extension_name, platform)
-    <<-EOF
-require 'rake/extensiontask'
-Rake::ExtensionTask.new("#{extension_name}", SPEC) do |ext|
-  ext.platform = "#{platform}"
-end
-EOF
+    <<~EOF
+      require 'rake/extensiontask'
+      Rake::ExtensionTask.new("#{extension_name}", SPEC) do |ext|
+        ext.platform = "#{platform}"
+      end
+    EOF
   end
 
   def template_rake_extension_cross_compile(extension_name, gem_spec = nil)
-    <<-EOF
-require 'rake/extensiontask'
-Rake::ExtensionTask.new("#{extension_name}"#{', SPEC' if gem_spec}) do |ext|
-  ext.cross_compile = true
-end
-EOF
+    <<~EOF
+      require 'rake/extensiontask'
+      Rake::ExtensionTask.new("#{extension_name}"#{', SPEC' if gem_spec}) do |ext|
+        ext.cross_compile = true
+      end
+    EOF
   end
 
   def template_rake_extension_multi_cross_compile(extension_name)
-    <<-EOF
-require 'rake/extensiontask'
-Rake::ExtensionTask.new("#{extension_name}", SPEC) do |ext|
-  ext.cross_compile = true
-  ext.cross_platform = ['i386-mswin32-60', 'i386-mingw32']
-end
-EOF
+    <<~EOF
+      require 'rake/extensiontask'
+      Rake::ExtensionTask.new("#{extension_name}", SPEC) do |ext|
+        ext.cross_compile = true
+        ext.cross_platform = ['i386-mswin32-60', 'i386-mingw32']
+      end
+    EOF
   end
 
   def template_rake_extension_java_compile(extension_name, gem_spec = nil)
-      <<-EOF
-require 'rake/javaextensiontask'
-Rake::JavaExtensionTask.new("#{extension_name}"#{', SPEC' if gem_spec}) do |ext|
-  # nothing
-end
-EOF
+    <<~EOF
+      require 'rake/javaextensiontask'
+      Rake::JavaExtensionTask.new("#{extension_name}"#{', SPEC' if gem_spec}) do |ext|
+        # nothing
+      end
+    EOF
   end
 
   def template_extconf(extension_name)
-    <<-EOF
-require 'mkmf'
-create_makefile("#{extension_name}")
-EOF
+    <<~EOF
+      require 'mkmf'
+      create_makefile("#{extension_name}")
+    EOF
   end
 
   def template_source_c(extension_name)
-    <<-EOF
-#include "source.h"
-void Init_#{extension_name}()
-{
-  printf("source.c of extension #{extension_name}\\n");
-}
-EOF
+    <<~EOF
+      #include "source.h"
+      void Init_#{extension_name}()
+      {
+        printf("source.c of extension #{extension_name}\\n");
+      }
+    EOF
   end
 
   def template_source_h
-    <<-EOF
-#include "ruby.h"
-EOF
+    <<~EOF
+      #include "ruby.h"
+    EOF
   end
 
   def template_source_java(extension_name)
-    <<-EOF
-import org.jruby.Ruby;
-import org.jruby.runtime.load.BasicLibraryService;
+    <<~EOF
+      import org.jruby.Ruby;
+      import org.jruby.runtime.load.BasicLibraryService;
 
-public class #{camelize(extension_name)}Service implements BasicLibraryService {
-   public boolean basicLoad(final Ruby runtime) throws java.io.IOException {
-     HelloWorldPrinter hwp = new HelloWorldPrinter();
-     hwp.tellTheWorld();
-     return true;
-   }
+      public class #{camelize(extension_name)}Service implements BasicLibraryService {
+         public boolean basicLoad(final Ruby runtime) throws java.io.IOException {
+           HelloWorldPrinter hwp = new HelloWorldPrinter();
+           hwp.tellTheWorld();
+           return true;
+         }
 
-   private class HelloWorldPrinter {
-     void tellTheWorld() throws java.io.IOException {
-       System.out.println("#{camelize(extension_name)}Service.java of extension #{extension_name}\\n");
-     }
-   }
-}
+         private class HelloWorldPrinter {
+           void tellTheWorld() throws java.io.IOException {
+             System.out.println("#{camelize(extension_name)}Service.java of extension #{extension_name}\\n");
+           }
+         }
+      }
 
-EOF
+    EOF
   end
 
   def camelize(str)
-    str.gsub(/(^|_)(.)/) { $2.upcase }
+    str.gsub(/(^|_)(.)/) { ::Regexp.last_match(2).upcase }
   end
-
 end
 
 World(FileTemplateHelpers)

--- a/features/support/generator_helpers.rb
+++ b/features/support/generator_helpers.rb
@@ -1,19 +1,19 @@
 module GeneratorHelpers
   def generate_scaffold_structure
     # create folder structure
-    FileUtils.mkdir_p "lib"
-    FileUtils.mkdir_p "tasks"
-    FileUtils.mkdir_p "tmp"
+    FileUtils.mkdir_p 'lib'
+    FileUtils.mkdir_p 'tasks'
+    FileUtils.mkdir_p 'tmp'
 
     # create Rakefile loader
-    File.open("Rakefile", 'w') do |rakefile|
+    File.open('Rakefile', 'w') do |rakefile|
       rakefile.puts template_rakefile.strip
     end
   end
 
   def generate_gem_task(gem_name)
     # create generic gem task
-    File.open("tasks/gem.rake", 'w') do |gem_rake|
+    File.open('tasks/gem.rake', 'w') do |gem_rake|
       gem_rake.puts template_rake_gemspec(gem_name)
     end
   end
@@ -25,8 +25,8 @@ module GeneratorHelpers
     return if File.exist?("tasks/#{extension_name}.rake")
 
     # Building a gem?
-    if File.exist?("tasks/gem.rake") then
-      File.open("tasks/gem.rake", 'a+') do |ext_in_gem|
+    if File.exist?('tasks/gem.rake')
+      File.open('tasks/gem.rake', 'a+') do |ext_in_gem|
         if platform
           ext_in_gem.puts template_rake_extension_with_platform(extension_name, platform)
         else
@@ -49,8 +49,8 @@ module GeneratorHelpers
 
     # create specific extension rakefile
     # Building a gem?
-    if File.exist?("tasks/gem.rake") then
-      File.open("tasks/gem.rake", 'a+') do |ext_in_gem|
+    if File.exist?('tasks/gem.rake')
+      File.open('tasks/gem.rake', 'a+') do |ext_in_gem|
         ext_in_gem.puts template_rake_extension_cross_compile(extension_name, true)
       end
     else
@@ -68,8 +68,8 @@ module GeneratorHelpers
 
     # create specific extension rakefile
     # Building a gem?
-    if File.exist?("tasks/gem.rake") then
-      File.open("tasks/gem.rake", 'a+') do |ext_in_gem|
+    if File.exist?('tasks/gem.rake')
+      File.open('tasks/gem.rake', 'a+') do |ext_in_gem|
         ext_in_gem.puts template_rake_extension_java_compile(extension_name, true)
       end
     else
@@ -87,10 +87,10 @@ module GeneratorHelpers
 
     # create specific extension rakefile
     # Building a gem?
-    if File.exist?("tasks/gem.rake") then
-      File.open("tasks/gem.rake", 'a+') do |ext_in_gem|
-        ext_in_gem.puts template_rake_extension_multi_cross_compile(extension_name)
-      end
+    return unless File.exist?('tasks/gem.rake')
+
+    File.open('tasks/gem.rake', 'a+') do |ext_in_gem|
+      ext_in_gem.puts template_rake_extension_multi_cross_compile(extension_name)
     end
   end
 
@@ -117,7 +117,6 @@ module GeneratorHelpers
       c.puts template_source_java(extension_name)
     end
   end
-
 end
 
 World(GeneratorHelpers)

--- a/features/support/platform_extension_helpers.rb
+++ b/features/support/platform_extension_helpers.rb
@@ -1,26 +1,25 @@
 module PlatformExtensionHelpers
   def binary_extension(platform = RUBY_PLATFORM)
     case platform
-      when /darwin/
-        'bundle'
-      when /mingw|mswin|linux/
-        'so'
-      when /java/
-        'jar'
-      else
-        RbConfig::CONFIG['DLEXT']
+    when /darwin/
+      'bundle'
+    when /mingw|mswin|linux/
+      'so'
+    when /java/
+      'jar'
+    else
+      RbConfig::CONFIG['DLEXT']
     end
   end
 
   def search_path(binaries)
     paths = ENV['PATH'].split(File::PATH_SEPARATOR)
-    binary = binaries.find do |bin_file|
+    binaries.find do |bin_file|
       paths.find do |path|
         bin = File.join(path, bin_file)
         File.exist?(bin) && File.executable?(bin)
       end
     end
-    binary
   end
 end
 

--- a/lib/rake/baseextensiontask.rb
+++ b/lib/rake/baseextensiontask.rb
@@ -5,20 +5,12 @@ require 'rbconfig'
 
 require 'pathname'
 
-require_relative "compiler_config"
+require_relative 'compiler_config'
 
 module Rake
   class BaseExtensionTask < TaskLib
-
-    attr_accessor :name
-    attr_accessor :gem_spec
-    attr_accessor :tmp_dir
-    attr_accessor :ext_dir
-    attr_accessor :lib_dir
-    attr_accessor :config_options
-    attr_accessor :source_pattern
-    attr_accessor :extra_options
-    attr_accessor :extra_sources
+    attr_accessor :name, :gem_spec, :tmp_dir, :ext_dir, :lib_dir, :config_options, :source_pattern, :extra_options,
+                  :extra_sources
     attr_writer :platform
 
     def platform
@@ -37,16 +29,15 @@ module Rake
       @tmp_dir = 'tmp'
       @ext_dir = "ext/#{@name}"
       @lib_dir = 'lib'
-      if @name and File.dirname(@name.to_s) != "."
-        @lib_dir += "/#{File.dirname(@name.to_s)}"
-      end
+      @lib_dir += "/#{File.dirname(@name.to_s)}" if @name and File.dirname(@name.to_s) != '.'
       @config_options = []
       @extra_options = ARGV.select { |i| i =~ /\A--?/ }
       @extra_sources = FileList[]
     end
 
     def define
-      fail "Extension name must be provided." if @name.nil?
+      raise 'Extension name must be provided.' if @name.nil?
+
       @name = @name.to_s
 
       define_compile_tasks
@@ -60,15 +51,15 @@ module Rake
 
     def binary(platform = nil)
       ext = case platform
-        when /darwin/
-          'bundle'
-        when /mingw|mswin|linux/
-          'so'
-        when /java/
-          'jar'
-        else
-          RbConfig::CONFIG['DLEXT']
-      end
+            when /darwin/
+              'bundle'
+            when /mingw|mswin|linux/
+              'so'
+            when /java/
+              'jar'
+            else
+              RbConfig::CONFIG['DLEXT']
+            end
       "#{@name}.#{ext}"
     end
 
@@ -79,6 +70,7 @@ module Rake
     def warn_once(message)
       @@already_warned ||= false
       return if @@already_warned
+
       @@already_warned = true
       warn message
     end

--- a/lib/rake/compiler_config.rb
+++ b/lib/rake/compiler_config.rb
@@ -1,7 +1,7 @@
 module Rake
   class CompilerConfig
     def initialize(config_path)
-      require "yaml"
+      require 'yaml'
       @config = YAML.load_file(config_path)
     end
 
@@ -23,13 +23,11 @@ module Rake
         # installation).
         #
         # With rubygems >= 3.3.21, only the second variation will be present.
-        runtime_platform_name = config_name.split("-")[1..-2].join("-")
-        runtime_version = config_name.split("-").last
+        runtime_platform_name = config_name.split('-')[1..-2].join('-')
+        runtime_version = config_name.split('-').last
         runtime_platform = Gem::Platform.new(runtime_platform_name)
 
-        if (ruby_version == runtime_version) && (gem_platform =~ runtime_platform)
-          return config_location
-        end
+        return config_location if (ruby_version == runtime_version) && (gem_platform =~ runtime_platform)
       end
 
       nil

--- a/lib/rake/extensioncompiler.rb
+++ b/lib/rake/extensioncompiler.rb
@@ -1,5 +1,4 @@
 module Rake
-
   #
   # HACK: Lousy API design, sue me. At least works ;-)
   #
@@ -12,7 +11,7 @@ module Rake
       return @mingw_host if @mingw_host
 
       # the mingw_gcc_executable is helpful here
-      if target = mingw_gcc_executable then
+      if target = mingw_gcc_executable
         # we only care for the filename
         target = File.basename(target)
 
@@ -23,7 +22,7 @@ module Rake
         target.sub!('-gcc', '')
       end
 
-      raise "No MinGW tools or unknown setup platform?" unless target
+      raise 'No MinGW tools or unknown setup platform?' unless target
 
       @mingw_host = target
     end
@@ -37,7 +36,7 @@ module Rake
       paths = ENV['PATH'].split(File::PATH_SEPARATOR)
 
       # the pattern to look into (captures *nix and windows executables)
-      pattern = "{mingw32-,i?86*mingw*,x86*mingw*}gcc{,.*}"
+      pattern = '{mingw32-,i?86*mingw*,x86*mingw*}gcc{,.*}'
 
       @mingw_gcc_executable = paths.find do |path|
         # cleanup paths before globbing

--- a/rake-compiler.gemspec
+++ b/rake-compiler.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   # basic information
-  s.name        = "rake-compiler"
-  s.version     = "1.2.2"
+  s.name        = 'rake-compiler'
+  s.version     = '1.2.2'
   s.platform    = Gem::Platform::RUBY
 
   # description and details
@@ -11,26 +11,26 @@ Gem::Specification.new do |s|
   s.description = "Provide a standard and simplified way to build and package\nRuby extensions (C, Java) using Rake as glue."
 
   # requirements
-  s.required_ruby_version = ">= 1.8.7"
-  s.required_rubygems_version = ">= 1.8.23"
+  s.required_ruby_version = '>= 2.5.0'
+  s.required_rubygems_version = '>= 1.8.23'
 
   # dependencies
-  s.add_dependency  'rake'
+  s.add_dependency 'rake'
 
   # development dependencies
   s.add_development_dependency 'bundler'
-  s.add_development_dependency 'rspec', '~> 2.8.0'
   s.add_development_dependency 'cucumber', '~> 1.1.4'
+  s.add_development_dependency 'rspec', '~> 2.8.0'
 
   # components, files and paths
-  s.files = Dir.glob("features/**/*.{feature,rb}")
-  s.files += ["bin/rake-compiler"]
-  s.files += Dir.glob("lib/**/*.rb")
-  s.files += ["spec/spec.opts"]
-  s.files += Dir.glob("spec/**/*.rb")
-  s.files += Dir.glob("tasks/**/*.rake")
-  s.files += ["Rakefile", "Gemfile"]
-  s.files += Dir.glob("*.{md,rdoc,txt,yml}")
+  s.files = Dir.glob('features/**/*.{feature,rb}')
+  s.files += ['bin/rake-compiler']
+  s.files += Dir.glob('lib/**/*.rb')
+  s.files += ['spec/spec.opts']
+  s.files += Dir.glob('spec/**/*.rb')
+  s.files += Dir.glob('tasks/**/*.rake')
+  s.files += %w[Rakefile Gemfile]
+  s.files += Dir.glob('*.{md,rdoc,txt,yml}')
 
   s.bindir      = 'bin'
   s.executables = ['rake-compiler']
@@ -38,9 +38,9 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   # documentation
-  s.rdoc_options << '--main'  << 'README.md' << '--title' << 'rake-compiler -- Documentation'
+  s.rdoc_options << '--main' << 'README.md' << '--title' << 'rake-compiler -- Documentation'
 
-  s.extra_rdoc_files = %w(README.md LICENSE.txt History.md)
+  s.extra_rdoc_files = %w[README.md LICENSE.txt History.md]
 
   # project information
   s.homepage          = 'https://github.com/rake-compiler/rake-compiler'

--- a/spec/lib/rake/compiler_config_spec.rb
+++ b/spec/lib/rake/compiler_config_spec.rb
@@ -12,7 +12,7 @@ describe Rake::CompilerConfig do
     end
   end
 
-  it "returns the matching config for exact platform match" do
+  it 'returns the matching config for exact platform match' do
     cc = Rake::CompilerConfig.new(config_file(<<~CONFIG))
       ---
       rbconfig-x86_64-linux-3.0.0: "/path/to/aaa/rbconfig.rb"
@@ -20,35 +20,33 @@ describe Rake::CompilerConfig do
       rbconfig-x86_64-linux-3.1.0: "/path/to/ccc/rbconfig.rb"
     CONFIG
 
-    expect(cc.find("3.0.0", "x86_64-linux")).to eq("/path/to/aaa/rbconfig.rb")
-    expect(cc.find("3.1.0", "x86_64-darwin")).to eq("/path/to/bbb/rbconfig.rb")
-    expect(cc.find("3.1.0", "x86_64-linux")).to eq("/path/to/ccc/rbconfig.rb")
+    expect(cc.find('3.0.0', 'x86_64-linux')).to eq('/path/to/aaa/rbconfig.rb')
+    expect(cc.find('3.1.0', 'x86_64-darwin')).to eq('/path/to/bbb/rbconfig.rb')
+    expect(cc.find('3.1.0', 'x86_64-linux')).to eq('/path/to/ccc/rbconfig.rb')
 
-    expect(cc.find("2.7.0", "x86_64-linux")).to be_nil
-    expect(cc.find("3.1.0", "arm64-linux")).to be_nil
+    expect(cc.find('2.7.0', 'x86_64-linux')).to be_nil
+    expect(cc.find('3.1.0', 'arm64-linux')).to be_nil
   end
 
-  it "returns the matching config for inexact platform match" do
+  it 'returns the matching config for inexact platform match' do
     cc = Rake::CompilerConfig.new(config_file(<<~CONFIG))
       ---
       rbconfig-x86_64-linux-gnu-3.0.0: "/path/to/aaa/rbconfig.rb"
       rbconfig-x86_64-linux-musl-3.1.0: "/path/to/bbb/rbconfig.rb"
     CONFIG
 
-    expect(cc.find("3.0.0", "x86_64-linux")).to eq("/path/to/aaa/rbconfig.rb")
-    expect(cc.find("3.1.0", "x86_64-linux")).to eq("/path/to/bbb/rbconfig.rb")
+    expect(cc.find('3.0.0', 'x86_64-linux')).to eq('/path/to/aaa/rbconfig.rb')
+    expect(cc.find('3.1.0', 'x86_64-linux')).to eq('/path/to/bbb/rbconfig.rb')
   end
 
-  it "does not match the other way around" do
-    if Gem::Version.new(Gem::VERSION) < Gem::Version.new("3.3.21")
-      skip "rubygems 3.3.21+ only"
-    end
+  it 'does not match the other way around' do
+    skip 'rubygems 3.3.21+ only' if Gem::Version.new(Gem::VERSION) < Gem::Version.new('3.3.21')
 
     cc = Rake::CompilerConfig.new(config_file(<<~CONFIG))
       ---
       rbconfig-x86_64-linux-3.1.0: "/path/to/bbb/rbconfig.rb"
     CONFIG
 
-    expect(cc.find("3.1.0", "x86_64-linux-musl")).to be_nil
+    expect(cc.find('3.1.0', 'x86_64-linux-musl')).to be_nil
   end
 end

--- a/spec/lib/rake/extensiontask_spec.rb
+++ b/spec/lib/rake/extensiontask_spec.rb
@@ -88,14 +88,14 @@ describe Rake::ExtensionTask do
     end
 
     it 'should look for C/C++ files pattern (.c,.cc,.cpp)' do
-      @ext.source_pattern.should == "*.{c,cc,cpp}"
+      @ext.source_pattern.should == '*.{c,cc,cpp}'
     end
 
     it 'should have no configuration options preset to delegate' do
       @ext.config_options.should be_empty
     end
 
-    it "should have no includes preset to delegate" do
+    it 'should have no includes preset to delegate' do
       @ext.config_includes.should be_empty
     end
 
@@ -125,7 +125,7 @@ describe Rake::ExtensionTask do
 
     context '(one extension)' do
       before :each do
-        allow(Rake::FileList).to receive(:[]).and_return(["ext/extension_one/source.c"], [])
+        allow(Rake::FileList).to receive(:[]).and_return(['ext/extension_one/source.c'], [])
         @ext = Rake::ExtensionTask.new('extension_one')
         @ext_bin = ext_bin('extension_one')
         @platform = RUBY_PLATFORM
@@ -172,11 +172,11 @@ describe Rake::ExtensionTask do
         end
 
         it "should depend on 'ext/extension_one/source.c'" do
-          Rake::Task["tmp/#{@platform}/extension_one/#{@ruby_ver}/#{@ext_bin}"].prerequisites.should include("ext/extension_one/source.c")
+          Rake::Task["tmp/#{@platform}/extension_one/#{@ruby_ver}/#{@ext_bin}"].prerequisites.should include('ext/extension_one/source.c')
         end
 
         it "should not depend on 'ext/extension_one/source.h'" do
-          Rake::Task["tmp/#{@platform}/extension_one/#{@ruby_ver}/#{@ext_bin}"].prerequisites.should_not include("ext/extension_one/source.h")
+          Rake::Task["tmp/#{@platform}/extension_one/#{@ruby_ver}/#{@ext_bin}"].prerequisites.should_not include('ext/extension_one/source.h')
         end
       end
 
@@ -190,7 +190,7 @@ describe Rake::ExtensionTask do
         end
 
         it "should depend on 'ext/extension_one/extconf.rb'" do
-          Rake::Task["tmp/#{@platform}/extension_one/#{@ruby_ver}/Makefile"].prerequisites.should include("ext/extension_one/extconf.rb")
+          Rake::Task["tmp/#{@platform}/extension_one/#{@ruby_ver}/Makefile"].prerequisites.should include('ext/extension_one/extconf.rb')
         end
       end
 
@@ -210,21 +210,21 @@ describe Rake::ExtensionTask do
         end
       end
 
-      it "should warn when pre-compiled files exist in extension directory" do
-        allow(Rake::FileList).to receive(:[]).
-          and_return(["ext/extension_one/source.c"],
-                      ["ext/extension_one/source.o"])
+      it 'should warn when pre-compiled files exist in extension directory' do
+        allow(Rake::FileList).to receive(:[])
+          .and_return(['ext/extension_one/source.c'],
+                      ['ext/extension_one/source.o'])
 
         _, err = capture_output do
           Rake::ExtensionTask.new('extension_one')
         end
-        err.should match(/rake-compiler found compiled files in 'ext\/extension_one' directory. Please remove them./)
+        err.should match(%r{rake-compiler found compiled files in 'ext/extension_one' directory. Please remove them.})
       end
     end
 
     context '(extension in custom location)' do
       before :each do
-        allow(Rake::FileList).to receive(:[]).and_return(["ext/extension_one/source.c"], [])
+        allow(Rake::FileList).to receive(:[]).and_return(['ext/extension_one/source.c'], [])
         @ext = Rake::ExtensionTask.new('extension_one') do |ext|
           ext.ext_dir = 'custom/ext/foo'
         end
@@ -235,14 +235,14 @@ describe Rake::ExtensionTask do
 
       context 'tmp/{platform}/extension_one/{ruby_ver}/Makefile' do
         it "should depend on 'custom/ext/foo/extconf.rb'" do
-          Rake::Task["tmp/#{@platform}/extension_one/#{@ruby_ver}/Makefile"].prerequisites.should include("custom/ext/foo/extconf.rb")
+          Rake::Task["tmp/#{@platform}/extension_one/#{@ruby_ver}/Makefile"].prerequisites.should include('custom/ext/foo/extconf.rb')
         end
       end
     end
 
     context '(native tasks)' do
       before :each do
-        allow(Rake::FileList).to receive(:[]).and_return(["ext/extension_one/source.c"], [])
+        allow(Rake::FileList).to receive(:[]).and_return(['ext/extension_one/source.c'], [])
         @spec = mock_gem_spec
         @ext_bin = ext_bin('extension_one')
         @platform = RUBY_PLATFORM
@@ -273,7 +273,7 @@ describe Rake::ExtensionTask do
 
         it 'should depend on platform specific native tasks' do
           Rake::ExtensionTask.new('extension_one', @spec)
-          Rake::Task["native"].prerequisites.should include("native:#{@platform}")
+          Rake::Task['native'].prerequisites.should include("native:#{@platform}")
         end
 
         context 'native:my_gem:{platform}' do
@@ -287,7 +287,7 @@ describe Rake::ExtensionTask do
 
     context '(one extension whose name with directory prefixes)' do
       before :each do
-        allow(Rake::FileList).to receive(:[]).and_return(["ext/prefix1/prefix2/extension_one/source.c"], [])
+        allow(Rake::FileList).to receive(:[]).and_return(['ext/prefix1/prefix2/extension_one/source.c'], [])
         @ext = Rake::ExtensionTask.new('prefix1/prefix2/extension_one')
         @ext_bin = ext_bin('extension_one')
         @platform = RUBY_PLATFORM
@@ -334,11 +334,11 @@ describe Rake::ExtensionTask do
         end
 
         it "should depend on 'ext/extension_one/source.c'" do
-          Rake::Task["tmp/#{@platform}/prefix1/prefix2/extension_one/#{@ruby_ver}/prefix1/prefix2/#{@ext_bin}"].prerequisites.should include("ext/prefix1/prefix2/extension_one/source.c")
+          Rake::Task["tmp/#{@platform}/prefix1/prefix2/extension_one/#{@ruby_ver}/prefix1/prefix2/#{@ext_bin}"].prerequisites.should include('ext/prefix1/prefix2/extension_one/source.c')
         end
 
         it "should not depend on 'ext/extension_one/source.h'" do
-          Rake::Task["tmp/#{@platform}/prefix1/prefix2/extension_one/#{@ruby_ver}/prefix1/prefix2/#{@ext_bin}"].prerequisites.should_not include("ext/prefix1/prefix2/extension_one/source.h")
+          Rake::Task["tmp/#{@platform}/prefix1/prefix2/extension_one/#{@ruby_ver}/prefix1/prefix2/#{@ext_bin}"].prerequisites.should_not include('ext/prefix1/prefix2/extension_one/source.h')
         end
       end
     end
@@ -347,9 +347,9 @@ describe Rake::ExtensionTask do
       before :each do
         allow(File).to receive(:exist?).and_return(true)
         allow(YAML).to receive(:load_file).and_return(mock_config_yml)
-        allow(Rake::FileList).to receive(:[]).and_return(["ext/extension_one/source.c"], [])
+        allow(Rake::FileList).to receive(:[]).and_return(['ext/extension_one/source.c'], [])
         @spec = mock_gem_spec
-        @config_file = File.expand_path("~/.rake-compiler/config.yml")
+        @config_file = File.expand_path('~/.rake-compiler/config.yml')
         @ruby_ver = RUBY_VERSION
         @platform = 'i386-mingw32'
         @config_path = mock_config_yml["rbconfig-#{@platform}-#{@ruby_ver}"]
@@ -369,14 +369,14 @@ describe Rake::ExtensionTask do
         end
 
         it 'should not generate a warning' do
-          @err.should eq("")
+          @err.should eq('')
         end
 
         it 'should create a dummy nested cross-compile target that raises an error' do
-          Rake::Task.should have_defined("cross")
-          Rake::Task["cross"].invoke
+          Rake::Task.should have_defined('cross')
+          Rake::Task['cross'].invoke
           lambda {
-            Rake::Task["compile"].invoke
+            Rake::Task['compile'].invoke
           }.should raise_error(RuntimeError,
                                /rake-compiler must be configured first to enable cross-compilation/)
         end
@@ -406,7 +406,7 @@ describe Rake::ExtensionTask do
         lambda {
           Rake::ExtensionTask.new('extension_one') do |ext|
             ext.cross_compiling do |gem_spec|
-              gem_spec.post_install_message = "Cross compiled gem"
+              gem_spec.post_install_message = 'Cross compiled gem'
             end
           end
         }.should_not raise_error
@@ -414,7 +414,7 @@ describe Rake::ExtensionTask do
 
       it 'should generate additional rake tasks if files are added when cross compiling' do
         allow_any_instance_of(Rake::CompilerConfig).to(
-          receive(:find).and_return("/rubies/1.9.1/rbconfig.rb")
+          receive(:find).and_return('/rubies/1.9.1/rbconfig.rb')
         )
 
         # Use a real spec instead of a mock because define_native_tasks dups and
@@ -438,15 +438,15 @@ describe Rake::ExtensionTask do
           end
         end
         Rake::Task['native:my_gem:universal-unknown'].execute
-        Rake::Task.should have_defined("tmp/universal-unknown/stage/somedir")
-        Rake::Task.should have_defined("tmp/universal-unknown/stage/somedir/somefile")
+        Rake::Task.should have_defined('tmp/universal-unknown/stage/somedir')
+        Rake::Task.should have_defined('tmp/universal-unknown/stage/somedir/somefile')
       end
 
       it 'should allow usage of RUBY_CC_VERSION to indicate a different version of ruby' do
         allow_any_instance_of(Rake::CompilerConfig).to(
           receive(:find)
-            .with("1.9.1", "i386-mingw32")
-            .and_return("/rubies/1.9.1/rbconfig.rb")
+            .with('1.9.1', 'i386-mingw32')
+            .and_return('/rubies/1.9.1/rbconfig.rb')
         )
 
         ENV['RUBY_CC_VERSION'] = '1.9.1'
@@ -458,13 +458,13 @@ describe Rake::ExtensionTask do
       it 'should allow multiple versions be supplied to RUBY_CC_VERSION' do
         allow_any_instance_of(Rake::CompilerConfig).to(
           receive(:find)
-            .with("1.8.6", "i386-mingw32")
-            .and_return("/rubies/1.8.6/rbconfig.rb")
+            .with('1.8.6', 'i386-mingw32')
+            .and_return('/rubies/1.8.6/rbconfig.rb')
         )
         allow_any_instance_of(Rake::CompilerConfig).to(
           receive(:find)
-            .with("1.9.1", "i386-mingw32")
-            .and_return("/rubies/1.9.1/rbconfig.rb")
+            .with('1.9.1', 'i386-mingw32')
+            .and_return('/rubies/1.9.1/rbconfig.rb')
         )
 
         ENV['RUBY_CC_VERSION'] = '1.8.6:1.9.1'
@@ -473,14 +473,14 @@ describe Rake::ExtensionTask do
         end
       end
 
-      it "should set required_ruby_version from RUBY_CC_VERSION, set platform, clear extensions but keep metadata" do
-        platforms = ["x86-mingw32", "x64-mingw32"]
-        ruby_cc_versions = ["1.8.6", "2.1.10", "2.2.6", "2.3.3", "2.10.1", "2.11.0"]
-        ENV["RUBY_CC_VERSION"] = ruby_cc_versions.join(":")
+      it 'should set required_ruby_version from RUBY_CC_VERSION, set platform, clear extensions but keep metadata' do
+        platforms = %w[x86-mingw32 x64-mingw32]
+        ruby_cc_versions = ['1.8.6', '2.1.10', '2.2.6', '2.3.3', '2.10.1', '2.11.0']
+        ENV['RUBY_CC_VERSION'] = ruby_cc_versions.join(':')
 
         ruby_cc_versions.each do |ruby_cc_version|
           platforms.each do |platform|
-            unless platform == "x64-mingw32" && ruby_cc_version == "2.11.0"
+            unless platform == 'x64-mingw32' && ruby_cc_version == '2.11.0'
               rbconf = "/rubies/#{ruby_cc_version}/rbconfig.rb"
             end
             allow_any_instance_of(Rake::CompilerConfig).to(
@@ -501,7 +501,7 @@ describe Rake::ExtensionTask do
         end
 
         cross_specs = []
-        Rake::ExtensionTask.new("extension_one", spec) do |ext|
+        Rake::ExtensionTask.new('extension_one', spec) do |ext|
           ext.cross_platform = platforms
           ext.cross_compile = true
           ext.cross_compiling do |cross_spec|
@@ -513,16 +513,16 @@ describe Rake::ExtensionTask do
         end
 
         expected_required_ruby_versions = [
-          Gem::Requirement.new([">= 1.8", "< 2.12.dev"]),
-          Gem::Requirement.new([">= 1.8", "< 2.11.dev"]),
+          Gem::Requirement.new(['>= 1.8', '< 2.12.dev']),
+          Gem::Requirement.new(['>= 1.8', '< 2.11.dev'])
         ]
         cross_specs.collect(&:required_ruby_version).should == expected_required_ruby_versions
         cross_specs.collect(&:extensions).should == [[], []]
         cross_specs.collect(&:platform).collect(&:to_s).should == platforms
-        cross_specs.collect{|s| s.metadata['allowed_push_host']}.should == ['http://test', 'http://test']
+        cross_specs.collect { |s| s.metadata['allowed_push_host'] }.should == ['http://test', 'http://test']
 
         # original gemspec should keep unchanged
-        spec.required_ruby_version.should == Gem::Requirement.new([">= 0"])
+        spec.required_ruby_version.should == Gem::Requirement.new(['>= 0'])
         spec.platform.should == Gem::Platform::RUBY
         spec.extensions.should == ['ext/somegem/extconf.rb']
         spec.metadata['allowed_push_host'].should == 'http://test'
@@ -532,17 +532,17 @@ describe Rake::ExtensionTask do
         ENV.delete('RUBY_CC_VERSION')
       end
 
-      context "(cross compile for multiple versions)" do
+      context '(cross compile for multiple versions)' do
         before :each do
           allow_any_instance_of(Rake::CompilerConfig).to(
             receive(:find)
-              .with("1.8.6", "universal-unknown")
-              .and_return("/rubies/1.8.6/rbconfig.rb")
+              .with('1.8.6', 'universal-unknown')
+              .and_return('/rubies/1.8.6/rbconfig.rb')
           )
           allow_any_instance_of(Rake::CompilerConfig).to(
             receive(:find)
-              .with("1.9.1", "universal-unknown")
-              .and_return("/rubies/1.9.1/rbconfig.rb")
+              .with('1.9.1', 'universal-unknown')
+              .and_return('/rubies/1.9.1/rbconfig.rb')
           )
 
           ENV['RUBY_CC_VERSION'] = '1.8.6:1.9.1'
@@ -553,8 +553,8 @@ describe Rake::ExtensionTask do
         end
 
         it 'should create specific copy of binaries for each version' do
-          Rake::Task.should have_defined("copy:extension_one:universal-unknown:1.8.6")
-          Rake::Task.should have_defined("copy:extension_one:universal-unknown:1.9.1")
+          Rake::Task.should have_defined('copy:extension_one:universal-unknown:1.8.6')
+          Rake::Task.should have_defined('copy:extension_one:universal-unknown:1.9.1')
         end
       end
 
@@ -588,7 +588,7 @@ describe Rake::ExtensionTask do
         end
 
         context 'compile:universal-unknown' do
-          it "should be defined" do
+          it 'should be defined' do
             Rake::Task.task_defined?('compile:universal-unknown').should == true
           end
 
@@ -598,7 +598,7 @@ describe Rake::ExtensionTask do
         end
 
         context 'native:universal-unknown' do
-          it "should be defined" do
+          it 'should be defined' do
             Rake::Task.task_defined?('native:universal-unknown').should == true
           end
 
@@ -612,9 +612,9 @@ describe Rake::ExtensionTask do
         before :each do
           @ext = Rake::ExtensionTask.new('extension_one', @spec) do |ext|
             ext.cross_compile = true
-            ext.cross_platform = ['universal-known', 'universal-unknown']
+            ext.cross_platform = %w[universal-known universal-unknown]
             ext.cross_config_options << '--with-something'
-            ext.cross_config_options << {'universal-known' => '--with-known'}
+            ext.cross_config_options << { 'universal-known' => '--with-known' }
           end
         end
 
@@ -632,33 +632,33 @@ describe Rake::ExtensionTask do
   end
 
   private
+
   def ext_bin(extension_name)
     "#{extension_name}.#{RbConfig::CONFIG['DLEXT']}"
   end
 
   def mock_gem_spec(stubs = {})
     double(Gem::Specification,
-      { :name => 'my_gem', :platform => 'ruby', :files => [] }.merge(stubs)
-    )
+           { name: 'my_gem', platform: 'ruby', files: [] }.merge(stubs))
   end
 
   def mock_config_yml
     return @mock_config_yml if @mock_config_yml
 
     versions = {
-      "1.8.6"      => "1.8",
-      "1.8.7"      => "1.8",
-      "1.9.3"      => "1.9.1",
-      "2.0.0"      => "2.0.0",
-      "2.1.2"      => "2.1.0",
-      RUBY_VERSION => RbConfig::CONFIG["ruby_version"]
+      '1.8.6' => '1.8',
+      '1.8.7' => '1.8',
+      '1.9.3' => '1.9.1',
+      '2.0.0' => '2.0.0',
+      '2.1.2' => '2.1.0',
+      RUBY_VERSION => RbConfig::CONFIG['ruby_version']
     }
 
     platforms = [
-      "i386-mingw32",
-      "universal-known",
-      "universal-unknown",
-      "x64-mingw32",
+      'i386-mingw32',
+      'universal-known',
+      'universal-unknown',
+      'x64-mingw32',
       RUBY_PLATFORM
     ]
 
@@ -674,6 +674,6 @@ describe Rake::ExtensionTask do
   end
 
   def mock_fake_rb
-    double(File, :write => 45)
+    double(File, write: 45)
   end
 end

--- a/spec/lib/rake/javaextensiontask_spec.rb
+++ b/spec/lib/rake/javaextensiontask_spec.rb
@@ -69,7 +69,7 @@ describe Rake::JavaExtensionTask do
     end
 
     it 'should look for Java files pattern (.java)' do
-      @ext.source_pattern.should == "**/*.java"
+      @ext.source_pattern.should == '**/*.java'
     end
 
     it 'should have no configuration options preset to delegate' do
@@ -94,7 +94,7 @@ describe Rake::JavaExtensionTask do
 
     context '(one extension)' do
       before :each do
-        allow(Rake::FileList).to receive(:[]).and_return(["ext/extension_one/source.java"])
+        allow(Rake::FileList).to receive(:[]).and_return(['ext/extension_one/source.java'])
         @ext = Rake::JavaExtensionTask.new('extension_one')
         @ext_bin = ext_bin('extension_one')
         @platform = 'java'
@@ -139,7 +139,7 @@ describe Rake::JavaExtensionTask do
           Rake::Task.task_defined?("tmp/#{@platform}/extension_one/#{@ext_bin}").should == true
         end
 
-        it "should depend on checkpoint file" do
+        it 'should depend on checkpoint file' do
           Rake::Task["tmp/#{@platform}/extension_one/#{@ext_bin}"].prerequisites.should include("tmp/#{@platform}/extension_one/.build")
         end
       end
@@ -150,7 +150,7 @@ describe Rake::JavaExtensionTask do
         end
 
         it 'should depend on source files' do
-          Rake::Task["tmp/#{@platform}/extension_one/.build"].prerequisites.should include("ext/extension_one/source.java")
+          Rake::Task["tmp/#{@platform}/extension_one/.build"].prerequisites.should include('ext/extension_one/source.java')
         end
       end
 
@@ -184,7 +184,7 @@ describe Rake::JavaExtensionTask do
         let(:release) { nil }
 
         it 'should honor the lint option' do
-          (extension.lint_option).should be_falsey
+          extension.lint_option.should be_falsey
           (extension.send :java_lint_arg).should eq '-Xlint'
         end
       end
@@ -194,34 +194,35 @@ describe Rake::JavaExtensionTask do
         let(:release) { nil }
 
         it 'should honor the lint option' do
-          (extension.lint_option).should eq lint_option
+          extension.lint_option.should eq lint_option
           (extension.send :java_lint_arg).should eq '-Xlint:deprecated'
         end
       end
 
-      context "without release option" do
+      context 'without release option' do
         let(:lint_option) { nil }
         let(:release) { nil }
 
         it 'should generate -target and -source build options' do
-          extension.target_version = "1.8"
-          extension.source_version = "1.8"
-          (extension.send :java_target_args).should eq ["-target", "1.8", "-source", "1.8"]
+          extension.target_version = '1.8'
+          extension.source_version = '1.8'
+          (extension.send :java_target_args).should eq ['-target', '1.8', '-source', '1.8']
         end
       end
 
-      context "with release option" do
+      context 'with release option' do
         let(:lint_option) { nil }
         let(:release) { '8' }
 
         it 'should generate --release option even with target_version/source_version' do
-          extension.target_version = "1.8"
-          extension.source_version = "1.8"
-          (extension.send :java_target_args).should eq ["--release=8"]
+          extension.target_version = '1.8'
+          extension.source_version = '1.8'
+          (extension.send :java_target_args).should eq ['--release=8']
         end
       end
     end
   end
+
   private
 
   def ext_bin(extension_name)
@@ -230,8 +231,6 @@ describe Rake::JavaExtensionTask do
 
   def mock_gem_spec(stubs = {})
     double(Gem::Specification,
-      { :name => 'my_gem', :platform => 'ruby' }.merge(stubs)
-    )
+           { name: 'my_gem', platform: 'ruby' }.merge(stubs))
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'rspec'
 
 # Console redirection helper
-require File.expand_path('../support/capture_output_helper', __FILE__)
+require File.expand_path('support/capture_output_helper', __dir__)
 
 RSpec.configure do |config|
   config.include CaptureOutputHelper

--- a/spec/support/capture_output_helper.rb
+++ b/spec/support/capture_output_helper.rb
@@ -1,5 +1,5 @@
 module CaptureOutputHelper
-  def capture_output(&block)
+  def capture_output
     old_stdout = $stdout
     old_stderr = $stderr
 

--- a/tasks/bin/cross-ruby.rake
+++ b/tasks/bin/cross-ruby.rake
@@ -26,33 +26,33 @@ rescue LoadError
 end
 
 require 'yaml'
-require "rbconfig"
+require 'rbconfig'
 
 # load compiler helpers
 # add lib directory to the search path
 libdir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'lib'))
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
-if RUBY_PLATFORM =~ /mingw|mswin/ then
-  puts "This command is meant to be executed under Linux or OSX, not Windows (is for cross-compilation)"
+if /mingw|mswin/.match?(RUBY_PLATFORM)
+  puts 'This command is meant to be executed under Linux or OSX, not Windows (is for cross-compilation)'
   exit(1)
 end
 
 require 'rake/extensioncompiler'
 
 MAKE = ENV['MAKE'] || %w[gmake make].find { |c| system("#{c} -v > /dev/null 2>&1") }
-USER_HOME = File.realpath(File.expand_path("~/.rake-compiler"))
+USER_HOME = File.realpath(File.expand_path('~/.rake-compiler'))
 RUBY_SOURCE = ENV['SOURCE']
-RUBY_BUILD = RbConfig::CONFIG["host"]
+RUBY_BUILD = RbConfig::CONFIG['host']
 
 # Unset any possible variable that might affect compilation
-["RUBYOPT"].each do |var|
+['RUBYOPT'].each do |var|
   ENV.delete(var)
 end
 
-RUBY_CC_VERSIONS = ENV.fetch("VERSION", "1.8.7-p371")
-RUBY_CC_VERSIONS.split(":").each do |ruby_cc_version|
-  ruby_cc_version = "ruby-" + ruby_cc_version
+RUBY_CC_VERSIONS = ENV.fetch('VERSION', '1.8.7-p371')
+RUBY_CC_VERSIONS.split(':').each do |ruby_cc_version|
+  ruby_cc_version = 'ruby-' + ruby_cc_version
   # grab the major "1.8" or "1.9" part of the version number
   major = ruby_cc_version.match(/.*-(\d.\d).\d/)[1]
 
@@ -76,19 +76,14 @@ RUBY_CC_VERSIONS.split(":").each do |ruby_cc_version|
   # ruby source file should be stored there
   file "#{USER_HOME}/sources/#{ruby_cc_version}.tar.gz" => ["#{USER_HOME}/sources"] do |t|
     # download the source file using wget or curl
-    if RUBY_SOURCE
-      url = RUBY_SOURCE
-    else
-      url = "http://cache.ruby-lang.org/pub/ruby/#{major}/#{File.basename(t.name)}"
-    end
+    url = RUBY_SOURCE || "http://cache.ruby-lang.org/pub/ruby/#{major}/#{File.basename(t.name)}"
     sh "wget #{url} || curl -O #{url}", chdir: File.dirname(t.name)
   end
 
   # Create tasks for each host out of the ":" separated hosts list in the HOST variable.
   # These tasks are processed in parallel as dependencies to the "install" task.
   mingw_hosts = ENV['HOST'] || Rake::ExtensionCompiler.mingw_host
-  mingw_hosts.split(":").each do |mingw_host|
-
+  mingw_hosts.split(':').each do |mingw_host|
     # Use Rake::ExtensionCompiler helpers to find the proper host
     mingw_target = mingw_host.gsub('msvc', '')
 
@@ -102,27 +97,26 @@ RUBY_CC_VERSIONS.split(":").each do |ruby_cc_version|
     CLOBBER.include(install_dir)
 
     task :mingw32 do
-      unless mingw_host then
-        warn "You need to install mingw32 cross compile functionality to be able to continue."
-        warn "Please refer to your distribution/package manager documentation about installation."
-        fail
+      unless mingw_host
+        warn 'You need to install mingw32 cross compile functionality to be able to continue.'
+        warn 'Please refer to your distribution/package manager documentation about installation.'
+        raise
       end
     end
 
     # generate the makefile in a clean build location
     file "#{build_dir}/Makefile" => [build_dir, source_dir] do |t|
-
       options = [
         "--host=#{mingw_host}",
         "--target=#{mingw_target}",
         "--build=#{RUBY_BUILD}",
         '--enable-shared',
         '--disable-install-doc',
-        '--with-ext=',
+        '--with-ext='
       ]
 
       # Force Winsock2 for Ruby 1.8, 1.9 defaults to it
-      options << "--with-winsock2" if major == "1.8"
+      options << '--with-winsock2' if major == '1.8'
       options << "--prefix=#{install_dir}"
       sh File.expand_path("#{USER_HOME}/sources/#{ruby_cc_version}/configure"), *options, chdir: File.dirname(t.name)
     end
@@ -136,14 +130,14 @@ RUBY_CC_VERSIONS.split(":").each do |ruby_cc_version|
     file "#{USER_HOME}/ruby/#{mingw_host}/#{ruby_cc_version}/bin/ruby.exe" => ["#{build_dir}/ruby.exe"] do |t|
       sh "#{MAKE} install", chdir: File.dirname(t.prerequisites.first)
     end
-    multitask :install => ["#{USER_HOME}/ruby/#{mingw_host}/#{ruby_cc_version}/bin/ruby.exe"]
+    multitask install: ["#{USER_HOME}/ruby/#{mingw_host}/#{ruby_cc_version}/bin/ruby.exe"]
   end
 end
 
-desc "Update rake-compiler list of installed Ruby versions"
+desc 'Update rake-compiler list of installed Ruby versions'
 task 'update-config' do
   config_file = "#{USER_HOME}/config.yml"
-  if File.exist?(config_file) then
+  if File.exist?(config_file)
     puts "Updating #{config_file}"
     config = YAML.load_file(config_file)
   else
@@ -154,12 +148,12 @@ task 'update-config' do
   files = Dir.glob("#{USER_HOME}/ruby/*/*/**/rbconfig.rb").sort
 
   files.each do |rbconfig|
-    version, platform = rbconfig.match(/.*-(\d.\d.\d).*\/([-\w]+)\/rbconfig/)[1,2]
+    version, platform = rbconfig.match(%r{.*-(\d.\d.\d).*/([-\w]+)/rbconfig})[1, 2]
     platforms = [platform]
 
     # fake alternate (binary compatible) i386-mswin32-60 platform
-    platform == "i386-mingw32" and
-      platforms.push "i386-mswin32-60"
+    platform == 'i386-mingw32' and
+      platforms.push 'i386-mswin32-60'
 
     platforms.each do |plat|
       config["rbconfig-#{plat}-#{version}"] = rbconfig
@@ -172,11 +166,11 @@ task 'update-config' do
     puts "Found Ruby version #{version} for platform #{platform} (#{rbconfig})"
   end
 
-  when_writing("Saving changes into #{config_file}") {
+  when_writing("Saving changes into #{config_file}") do
     File.open(config_file, 'w') do |f|
       f.puts config.to_yaml
     end
-  }
+  end
 end
 
 task :default do
@@ -185,5 +179,5 @@ task :default do
   Rake.application.display_tasks_and_comments
 end
 
-desc "Build rubies suitable for cross-platform development."
+desc 'Build rubies suitable for cross-platform development.'
 task 'cross-ruby' => [:mingw32, :install, 'update-config']

--- a/tasks/bootstrap.rake
+++ b/tasks/bootstrap.rake
@@ -1,8 +1,8 @@
 desc 'Ensure all the cross compiled versions are installed'
 task :bootstrap do
-  fail "Sorry, this only works on OSX and Linux" if RUBY_PLATFORM =~ /mswin|mingw/
+  raise 'Sorry, this only works on OSX and Linux' if /mswin|mingw/.match?(RUBY_PLATFORM)
 
-  versions = %w(1.8.7-p371 1.9.3-p392 2.0.0-p0)
+  versions = %w[1.8.7-p371 1.9.3-p392 2.0.0-p0]
 
   versions.each do |version|
     puts "[INFO] Attempt to cross-compile Ruby #{version}"

--- a/tasks/common.rake
+++ b/tasks/common.rake
@@ -4,7 +4,7 @@ require 'rake/clean'
 CLOBBER.include('tmp')
 
 # set default task
-task :default => [:spec, :features]
+task default: %i[spec features]
 
 # make packing depend on success of running specs and features
-task :package => [:spec, :features]
+task package: %i[spec features]

--- a/tasks/cucumber.rake
+++ b/tasks/cucumber.rake
@@ -1,7 +1,7 @@
 begin
   require 'cucumber/rake/task'
 rescue LoadError
-  warn "Cucumber gem is required, please install it. (gem install cucumber)"
+  warn 'Cucumber gem is required, please install it. (gem install cucumber)'
 end
 
 if defined?(Cucumber)
@@ -16,8 +16,8 @@ if defined?(Cucumber)
     end
 
     desc 'Run all features'
-    task :all => [:default, :java]
+    task all: %i[default java]
   end
   desc 'Alias for cucumber:default'
-  task :cucumber => 'cucumber:default'
+  task cucumber: 'cucumber:default'
 end

--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -1,5 +1,5 @@
-require "bundler/gem_helper"
+require 'bundler/gem_helper'
 
-base_dir = File.join(__dir__, "..")
+base_dir = File.join(__dir__, '..')
 helper = Bundler::GemHelper.new(base_dir)
 helper.install

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -1,9 +1,7 @@
 begin
-  require "rspec/core/rake_task"
+  require 'rspec/core/rake_task'
 rescue LoadError => e
-  warn "RSpec gem is required, please install it (gem install rspec)."
+  warn 'RSpec gem is required, please install it (gem install rspec).'
 end
 
-if defined?(RSpec::Core::RakeTask)
-  RSpec::Core::RakeTask.new(:spec)
-end
+RSpec::Core::RakeTask.new(:spec) if defined?(RSpec::Core::RakeTask)


### PR DESCRIPTION
this PR drops support for long EOL rubies as suggested by https://github.com/rake-compiler/rake-compiler/pull/213#discussion_r1152473377

some gems still supports very versions, but I think Ruby 2.5 should be a reasonable minimum. This version is also currently tested by Github actions.
```
required_ruby_version = '>= 2.5.0'
```

it also applies rubocop autocorrect for Ruby 2.5 feature level (just styling)