### PR TITLE
handle nil in config options (broken in 1.2.2)

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -80,30 +80,21 @@ module Rake
     end
 
     def make_makefile_cmd(root_path, tmp_path, extconf, siteconf_path, cross_platform) # :nodoc:
-      options = @config_options.dup
-
       # include current directory
       include_dirs = ['.'].concat(@config_includes).uniq.join(File::PATH_SEPARATOR)
-      cmd = [Gem.ruby, "-I#{include_dirs}", "-r#{File.basename(siteconf_path)}"]
 
       # build a relative path to extconf script
       abs_tmp_path = (Pathname.new(root_path) + tmp_path).realpath
       abs_extconf = (Pathname.new(root_path) + extconf).realpath
+      rel_extconf = abs_extconf.relative_path_from(abs_tmp_path).to_s
 
-      # now add the extconf script
-      cmd << abs_extconf.relative_path_from(abs_tmp_path).to_s
+      # base command
+      cmd = [Gem.ruby, "-I#{include_dirs}", "-r#{File.basename(siteconf_path)}", rel_extconf]
 
-      if cross_platform
-        options.push(*cross_config_options(cross_platform))
-      end
-
-      # add options to command
-      cmd.push(*options)
-
-      # add any extra command line options
-      unless extra_options.empty?
-        cmd.push(*extra_options)
-      end
+      # add all the options
+      cmd += @config_options
+      cmd += cross_config_options(cross_platform) if cross_platform
+      cmd += extra_options
 
       cmd.compact
     end

--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -105,7 +105,7 @@ module Rake
         cmd.push(*extra_options)
       end
 
-      cmd
+      cmd.compact
     end
 
     private

--- a/spec/lib/rake/extensiontask_spec.rb
+++ b/spec/lib/rake/extensiontask_spec.rb
@@ -285,6 +285,67 @@ describe Rake::ExtensionTask do
       end
     end
 
+    context 'make_makefile_cmd' do
+      around :each do |test|
+        @tmp_path = "injectedtmp"
+        @extconf = "injectedextconf.rb"
+        @siteconf_path = "#{@tmp_path}/.injected-siteconf.rb"
+
+        Dir.mktmpdir do |root_path|
+          @root_path = root_path
+          FileUtils.mkdir_p("#{root_path}/#{@tmp_path}")
+          FileUtils.touch("#{root_path}/#{@extconf}")
+
+          @ext = Rake::ExtensionTask.new('extension_test') do |ext|
+            # repeats to test deduplication
+            ext.config_includes += ["/injected/include1", "/injected/include1", "/injected/include2"]
+            ext.config_options << "--with-a"
+            ext.extra_options = ["--", "--with-b"] # normally set based on ARGV
+            ext.cross_config_options << '--with-c'
+            ext.cross_config_options << {'universal-known' => '--with-d'}
+            ext.cross_config_options << {'universal-unknown' => '--with-e'}
+          end
+
+          Dir.chdir(root_path) do
+            test.run
+          end
+        end
+      end
+
+      it "runs the extconf with proper arguments when not cross-compiling" do
+        command = @ext.make_makefile_cmd(@root_path, @tmp_path, @extconf, @siteconf_path, nil)
+
+        expected_includes = [".", "/injected/include1", "/injected/include2"].join(File::PATH_SEPARATOR)
+        expected = [
+          Gem.ruby,
+          "-I#{expected_includes}",
+          "-r.injected-siteconf.rb",
+          "../#{@extconf}",
+          "--with-a", # config_options
+          "--", "--with-b", # extra_options
+        ]
+
+        command.should eq(expected)
+      end
+
+      it "runs the extconf with proper arguments when cross-compiling" do
+        command = @ext.make_makefile_cmd(@root_path, @tmp_path, @extconf, @siteconf_path, "universal-known")
+
+        expected_includes = [".", "/injected/include1", "/injected/include2"].join(File::PATH_SEPARATOR)
+        expected = [
+          Gem.ruby,
+          "-I#{expected_includes}",
+          "-r.injected-siteconf.rb",
+          "../#{@extconf}",
+          "--with-a", # config_options
+          "--with-c", "--with-d", # cross_config_options
+          "--", "--with-b" # extra_options
+        ]
+
+        command.should eq(expected)
+      end
+    end
+
     context '(one extension whose name with directory prefixes)' do
       before :each do
         allow(Rake::FileList).to receive(:[]).and_return(["ext/prefix1/prefix2/extension_one/source.c"], [])

--- a/spec/lib/rake/extensiontask_spec.rb
+++ b/spec/lib/rake/extensiontask_spec.rb
@@ -362,6 +362,24 @@ describe Rake::ExtensionTask do
 
         command.should eq(expected)
       end
+
+      it "handles 'nil' in the command array gracefully" do
+        @ext.config_options << nil # imagine this is ENV['NONEXISTENT_VALUE']
+
+        command = @ext.make_makefile_cmd(@root_path, @tmp_path, @extconf, @siteconf_path, nil)
+
+        expected_includes = [".", "/injected/include1", "/injected/include2"].join(File::PATH_SEPARATOR)
+        expected = [
+          Gem.ruby,
+          "-I#{expected_includes}",
+          "-r.injected-siteconf.rb",
+          "../#{@extconf}",
+          "--with-a", # config_options
+          "--", "--with-b", # extra_options
+        ]
+
+        command.should eq(expected)
+      end
     end
 
     context '(one extension whose name with directory prefixes)' do

--- a/spec/lib/rake/extensiontask_spec.rb
+++ b/spec/lib/rake/extensiontask_spec.rb
@@ -344,6 +344,24 @@ describe Rake::ExtensionTask do
 
         command.should eq(expected)
       end
+
+      it "handles spaces in arguments correctly" do
+        @ext.extra_options << "--with-spaces='a b'"
+
+        command = @ext.make_makefile_cmd(@root_path, @tmp_path, @extconf, @siteconf_path, nil)
+
+        expected_includes = [".", "/injected/include1", "/injected/include2"].join(File::PATH_SEPARATOR)
+        expected = [
+          Gem.ruby,
+          "-I#{expected_includes}",
+          "-r.injected-siteconf.rb",
+          "../#{@extconf}",
+          "--with-a", # config_options
+          "--", "--with-b", "--with-spaces='a b'", # extra_options
+        ]
+
+        command.should eq(expected)
+      end
     end
 
     context '(one extension whose name with directory prefixes)' do


### PR DESCRIPTION
__Context__

In rake-compiler 1.2.1 and earlier, if an extension did something like this, rake-compiler handled it gracefully:

```ruby
  Rake::ExtensionTask.new("gem", spec) do |ext|
    ext.config_options << ENV["EXTOPTS"] # this is probably going to be nil
  end
```

It is OK to do this because in 1.2.1 and earlier, the command array was executed as:

```
  sh cmd.join(' ')
```

However, this was changed in 1.2.2 to

```
  sh *cmd
```

which of course is preferable. However, this breaks extensions [like nokogiri that do something silly like above](https://github.com/sparklemotion/nokogiri/actions/runs/5109347425/jobs/9184057367).

__Details__

I've fixed Nokogiri (see https://github.com/sparklemotion/nokogiri/pull/2894) but I do think that there may be other gems impacted by this change.

This PR does a few things:

- extract a method `make_makefile_cmd` so that we can unit test it
- backfill basic test coverage
- backfill test for #215
- write a test for this `nil` case, and fix it by returning the result of `cmd.compact`

This is a big PR because of the extraction and test coverage. Please let me know if you would prefer this to be done a different way.