### PR TITLE
Restore Ruby 2.5 support broken in v1.2.4

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -163,7 +163,7 @@ module Rake
       task "copy:#{@name}:#{platf}:#{ruby_ver}" => [lib_path, tmp_binary_path, "#{tmp_path}/Makefile"] do
         # install in lib for native platform only
         unless for_platform
-          relative_lib_path = Pathname(lib_path).relative_path_from(tmp_path)
+          relative_lib_path = Pathname(lib_path).relative_path_from(Pathname.new(tmp_path))
 
           make_command_line = Shellwords.shellsplit(make)
           make_command_line << "install"


### PR DESCRIPTION
Pathname#relative_path_from supports string arguments only in Ruby 2.6+ (see https://github.com/ruby/ruby/commit/dde0e30c)

Fixes #224