### PR TITLE
test: add windows and ruby 3.2 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,14 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
+          - windows-latest
         ruby:
           - "2.5"
           - "2.6"
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
           - head
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Trying to generate a failing test for #225