### PR TITLE
Avoid giving Pathname#relative_path_from a String for Ruby < 2.6 compat

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -163,7 +163,7 @@ module Rake
       task "copy:#{@name}:#{platf}:#{ruby_ver}" => [lib_path, tmp_binary_path, "#{tmp_path}/Makefile"] do
         # install in lib for native platform only
         unless for_platform
-          relative_lib_path = Pathname(lib_path).relative_path_from(tmp_path)
+          relative_lib_path = Pathname(lib_path).relative_path_from(Pathname(tmp_path))
 
           make_command_line = Shellwords.shellsplit(make)
           make_command_line << "install"


### PR DESCRIPTION
rake-compiler started to fail on Ruby 2.5 since its version 1.2.4. Here's an actual failure that I saw on haml project, https://github.com/haml/haml/actions/runs/5740494510/job/15558470282#step:5:26
which fails with `NoMethodError: undefined method `cleanpath' for "tmp/x86_64-linux/haml/2.5.9":String`.

The error seems to be raised from this line https://github.com/rake-compiler/rake-compiler/blob/77d9294a203a11b39ee2e3d295e91706049b91ea/lib/rake/extensiontask.rb#L166
and it can be blamed to 0d93b08912c3afad7bbc7e02b080881a09ab1b27.

This happens because `Pathname#relative_path_from` used not to accept a String parameter until https://github.com/ruby/ruby/pull/2049 (ruby/ruby@4cf828632f3e2411b4c141fb30b2edf4844351fa and ruby/ruby@78dc3da299f49eec2783190ad72812852750f40e).

The CI on this repo is passing on Ruby 2.5 although it's not working, because there are no test that tries to run `copy:*` task, whereas there exist some tests that test the definition or dependency to that task. I'm not sure if I'd better add such a test, but for now, let me just post a minimum patch that should fix the error.