### PR TITLE
set `required_rubygems_version` for native gems that specify the linux libc

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -278,6 +278,16 @@ Java extension should be preferred.
             "< #{ruby_api_version(sorted_ruby_versions.last).succ}.dev"
           ]
 
+          # set rubygems version constraints
+          if Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.3.22") &&
+             spec.platform.os == "linux" && !spec.platform.version.nil?
+            spec.required_rubygems_version = if spec.required_rubygems_version == Gem::Requirement.default
+              [">= 3.3.22"]
+            else
+              Gem::Requirement.new(gem_spec.required_rubygems_version, ">= 3.3.22")
+            end
+          end
+
           # clear the extensions defined in the specs
           spec.extensions.clear
 


### PR DESCRIPTION
### Problem I'm trying to solve

Rubygems does not correctly recognize `-musl` or `-gnu` platform suffixes until v3.3.22.

### Solution

If rake-compiler is building a linux native gem that specifies a libc in its platform object, then add ">= 3.3.22" to the required_rubygems_version requirement.

https://github.com/rubygems/rubygems/blob/master/CHANGELOG.md#3322--2022-09-07

### Context

While working on musl support in the precompilation toolchain:

- https://github.com/rake-compiler/rake-compiler-dock/pull/111
- https://github.com/flavorjones/ruby-c-extensions-explained/pull/27
- https://github.com/sparklemotion/sqlite3-ruby/pull/442
- https://github.com/sparklemotion/nokogiri/pull/3111

I noticed that Ruby 3.0 is still shipping with Rubygems 3.2.33, which does not recognize these gem platforms. 

Specifying the rubygems requirement changes the error experienced by users during gem installation from:

> ERROR:  While executing gem ... (Gem::Exception)
>     Unable to find spec for #<Gem::NameTuple rcee_precompiled, 0.6.test.2024.0128.1724, aarch64-linux>

to:

> ERROR:  Error installing rcee_precompiled-0.6.test.2024.0128.1735-x86_64-linux-musl.gem:
>       rcee_precompiled-0.6.test.2024.0128.1735-x86_64-linux-musl requires RubyGems version >= 3.3.22.
> The current RubyGems version is 3.2.33. Try 'gem update --system' to update RubyGems itself.

/cc @deivid-rodriguez @segiddins