### PR TITLE
Update mingw website

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,9 +288,9 @@ On OSX, we no longer recommend the usage of MacPorts `mingw32` package because
 it stagnated in GCC version 3.4.5.
 
 Instead we recommend you download mingw-w64 automated build packages available at
-SourceForge:
+OSDN:
 
-http://sourceforge.net/downloads/mingw-w64/
+https://osdn.net/projects/mingw/
 
 Browse into *Toolchains targetting Win32* and then *Automated Builds*.
 


### PR DESCRIPTION
The project moved off of sourceforge a long time ago. Unfortunately, I can't find the files that the readme references, so maybe this whole section should be removed since it is sort of an area a user will have to research today if they want to avoid rake-compile-dock on OSX.