### PR TITLE
Don't generate additional rake tasks when files don't exist

### DIFF
--- a/lib/rake/extensiontask.rb
+++ b/lib/rake/extensiontask.rb
@@ -86,8 +86,8 @@ module Rake
       lib_binary_path = "#{lib_path}/#{File.basename(binary(platf))}"
 
       files.each do |gem_file|
-        # ignore directories and the binary extension
-        next if File.directory?(gem_file) || gem_file == lib_binary_path
+        # ignore directories, the binary extension and non-existent files
+        next if File.directory?(gem_file) || gem_file == lib_binary_path || !File.exist?(gem_file)
         stage_file = "#{stage_path}/#{gem_file}"
 
         # copy each file from base to stage directory

--- a/spec/lib/rake/extensiontask_spec.rb
+++ b/spec/lib/rake/extensiontask_spec.rb
@@ -412,10 +412,11 @@ describe Rake::ExtensionTask do
         }.should_not raise_error
       end
 
-      it 'should generate additional rake tasks if files are added when cross compiling' do
+      it 'should generate additional rake tasks if files are added when cross compiling and files exist' do
         allow_any_instance_of(Rake::CompilerConfig).to(
           receive(:find).and_return("/rubies/1.9.1/rbconfig.rb")
         )
+        expect(File).to receive(:exist?).with('somedir/non-existent-file').and_return(false)
 
         # Use a real spec instead of a mock because define_native_tasks dups and
         # calls methods on Gem::Specification, which is more than mock can do.
@@ -435,11 +436,13 @@ describe Rake::ExtensionTask do
           ext.cross_platform = 'universal-unknown'
           ext.cross_compiling do |gem_spec|
             gem_spec.files << 'somedir/somefile'
+            gem_spec.files << 'somedir/non-existent-file'
           end
         end
         Rake::Task['native:my_gem:universal-unknown'].execute
         Rake::Task.should have_defined("tmp/universal-unknown/stage/somedir")
         Rake::Task.should have_defined("tmp/universal-unknown/stage/somedir/somefile")
+        Rake::Task.should_not have_defined("tmp/universal-unknown/stage/somedir/non-existent-file")
       end
 
       it 'should allow usage of RUBY_CC_VERSION to indicate a different version of ruby' do


### PR DESCRIPTION
If files is retrieved from Git and the task is executed after the files are deleted but before they are committed to Git, an error occurs because the files do not exist.

Getting files from Git is a common pattern because it's default of newgems by generated by Bundler.
https://github.com/rubygems/rubygems/blob/ad394cadc73f2239b907e6cd02a0dfae2ef65999/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt#L31-L35

I would like to avoid an error in this situation, so I fixed not to create rake tasks for compile if files don't exist.