### PR TITLE
Default to Java 8 build target at minimum

### DIFF
--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -38,8 +38,8 @@ module Rake
       @source_pattern = '**/*.java'
       @classpath      = nil
       @debug          = false
-      @source_version = '1.7'
-      @target_version = '1.7'
+      @source_version = '8'
+      @target_version = '8'
       @release        = nil
       @encoding       = nil
       @java_compiling = nil


### PR DESCRIPTION
Java 21, the minimum Java for upcoming JRuby 10, can only compile Java code to target Java 8 or higher. This causes projects that have not explicitly configured their source_level and target_level to fail building on such recent JDKs.

This patch sets the minimum to Java 8, which is the minimum version for JRuby versions 9.2 and higher (with 9.2 and 9.3 already EOL).

This can be merged and released any time and I believe it is a safe change.