### PR TITLE
fix: rake task 'update-config' supports double-digit version segments

### DIFF
--- a/tasks/bin/cross-ruby.rake
+++ b/tasks/bin/cross-ruby.rake
@@ -154,7 +154,7 @@ task 'update-config' do
   files = Dir.glob("#{USER_HOME}/ruby/*/*/**/rbconfig.rb").sort
 
   files.each do |rbconfig|
-    version, platform = rbconfig.match(/.*-(\d.\d.\d).*\/([-\w]+)\/rbconfig/)[1,2]
+    version, platform = rbconfig.match(/.*-(\d+\.\d+\.\d+).*\/([-\w]+)\/rbconfig/)[1,2]
     platforms = [platform]
 
     # fake alternate (binary compatible) i386-mswin32-60 platform


### PR DESCRIPTION
rake-compiler does not correctly configure a ruby with a double-digit version segment. For example, if I build 2.6.10, the `config.yml` will contain an entry for `2.6.1`.

Previously the regexp used was

    (\d.\d.\d.)

Now the regexp is

    (\d+\.\d+\.\d+)