### PR TITLE
javaextensiontask.rb - check `javac` path using `JAVA_HOME`

### DIFF
--- a/lib/rake/javaextensiontask.rb
+++ b/lib/rake/javaextensiontask.rb
@@ -108,8 +108,15 @@ execute the Rake compilation task using the JRuby interpreter.
         EOF
         warn_once(not_jruby_compile_msg) unless defined?(JRUBY_VERSION)
 
+        java_home = ENV["JAVA_HOME"]
+        if java_home
+          javac_path = File.join(java_home, "bin", "javac")
+          javac_path = nil unless File.exist?(javac_path)
+        end
+        javac_path ||= "javac" 
+
         javac_command_line = [
-          "javac",
+          javac_path,
           *java_target_args,
           java_lint_arg,
           "-d", tmp_path,
@@ -306,7 +313,7 @@ execute the Rake compilation task using the JRuby interpreter.
 
     def release_flag_supported?
       return true unless RUBY_PLATFORM =~ /java/
-      
+
       Gem::Version.new(Java::java.lang.System.getProperty('java.version')) >= Gem::Version.new("9")
     end
   end


### PR DESCRIPTION
JRuby-head is using JDK 21.  This is not the default on GHA.  `setup-ruby` added code to change `JAVA_HOME`, assuming it would trigger the correct JDK being used.

Puma tests against jruby-head, and it was failing when rake compile ran.  After reviewing the code, `javac` is being called without a path.

Added code to check if `File.join(ENV["JAVA_HOME"], "bin", "javac")` exists.  If it does, use the full path, otherwise fallback to current behavior.

I changed the Gemfile in Puma to use the PR branch, and the job correctly compiles.

